### PR TITLE
fix: remove unresolved import for tauriExtensionHost.contribution

### DIFF
--- a/src/vs/workbench/workbench.common.main.ts
+++ b/src/vs/workbench/workbench.common.main.ts
@@ -299,7 +299,6 @@ import './contrib/externalUriOpener/common/externalUriOpener.contribution.js';
 // Extensions Management
 import './contrib/extensions/browser/extensions.contribution.js';
 import './contrib/extensions/browser/extensionsViewlet.js';
-import './contrib/extensions/browser/tauriExtensionHost.contribution.js';
 
 // Output View
 import './contrib/output/browser/output.contribution.js';


### PR DESCRIPTION
## Problem

`npm run tauri dev` fails with a Vite build error:

```
Failed to resolve import "./contrib/extensions/browser/tauriExtensionHost.contribution.js"
from "src/vs/workbench/workbench.common.main.ts". Does the file exist?
```

The import at line 302 of `workbench.common.main.ts` references a file that was never created.

## Fix

Remove the dangling import to unblock local development.

If Tauri-specific extension host registration is needed in the future, the corresponding file (`tauriExtensionHost.contribution.ts`) should be created before re-adding this import.