### PR TITLE
fix(extensions): bump VS Code API version to a published release

### DIFF
--- a/scripts/setup-extensions.sh
+++ b/scripts/setup-extensions.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-VSCODE_VERSION="1.110.0"
+VSCODE_VERSION="1.115.0"
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 EXTENSIONS_DIR="$REPO_ROOT/extensions"
 


### PR DESCRIPTION
## Summary

`scripts/setup-extensions.sh` pinned `VSCODE_VERSION=1.110.0`, which is not a published VS Code release on the Marketplace. Running the setup script fails to resolve/download built-in extensions because the version doesn't exist.

Bumped to `1.115.0`, a valid published version, so extension setup succeeds out of the box.

## Change

- `scripts/setup-extensions.sh`: `VSCODE_VERSION` `1.110.0` → `1.115.0`

## Test plan

- [x] Ran `./scripts/setup-extensions.sh` — extensions resolve and download successfully
- [x] `npm run tauri dev` launches with built-in extensions present