### PR TITLE
fix: circular chunks

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -94,14 +94,11 @@ export default defineConfig({
           if (id.endsWith('/vs/nls.ts') || id.endsWith('/vs/nls.js')) {
             return 'nls';
           }
-          if (id.includes('/vs/base/') || id.endsWith('/vs/amdX.ts') || id.endsWith('/vs/amdX.js') || id.endsWith('/vs/sidex-bridge.ts') || id.endsWith('/vs/sidex-bridge.js')) {
-            return 'base';
-          }
-
-          if (id.includes('xterm') || id.includes('/terminal/')) {
-            return 'terminal';
-          }
           if (
+            id.includes('/vs/base/') ||
+            id.endsWith('/vs/amdX.ts') || id.endsWith('/vs/amdX.js') ||
+            id.endsWith('/vs/sidex-bridge.ts') || id.endsWith('/vs/sidex-bridge.js') ||
+            id.includes('xterm') || id.includes('/terminal/') ||
             (id.includes('/vs/editor/') && !id.includes('/workbench/')) ||
             id.includes('/vs/platform/')
           ) {


### PR DESCRIPTION
This removes `base | terminal` to be in `core` which was causing Prod Binary launch to show a grey screen with nothing. 

