### PR TITLE
fix: update extensionsGallery configuration for local development and  nhance extension gallery configuration and add NullWorkbenchIssueService

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
 				licenseName: 'MIT',
 				licenseUrl: 'https://github.com/sidenai/sidex/blob/main/LICENSE',
 				extensionsGallery: (() => {
-					const isDev = window.location.origin.includes('localhost:1420');
+					const isDev = ['localhost', '127.0.0.1', '[::1]'].includes(window.location.hostname);
 					const openVsx = isDev ? window.location.origin + '/open-vsx-proxy' : 'https://open-vsx.org';
 					return {
 						serviceUrl: 'https://marketplace.siden.ai/api/gallery',

--- a/index.html
+++ b/index.html
@@ -44,18 +44,21 @@
 				reportIssueUrl: 'https://github.com/sidenai/sidex/issues/new',
 				licenseName: 'MIT',
 				licenseUrl: 'https://github.com/sidenai/sidex/blob/main/LICENSE',
-				extensionsGallery: {
-					serviceUrl: 'https://marketplace.siden.ai/api/gallery',
-					itemUrl: 'https://open-vsx.org/vscode/item',
-					resourceUrlTemplate: 'https://open-vsx.org/vscode/unpkg/{publisher}/{name}/{version}/{path}',
-					controlUrl: '',
-					nlsBaseUrl: 'https://open-vsx.org/vscode/unpkg/{publisher}/{name}/{version}/extension',
-					publisherUrl: ''
-				}
+				extensionsGallery: (() => {
+					const isDev = window.location.origin.includes('localhost:1420');
+					const openVsx = isDev ? window.location.origin + '/open-vsx-proxy' : 'https://open-vsx.org';
+					return {
+						serviceUrl: 'https://marketplace.siden.ai/api/gallery',
+						itemUrl: openVsx + '/vscode/item',
+						resourceUrlTemplate: openVsx + '/vscode/unpkg/{publisher}/{name}/{version}/{path}',
+						controlUrl: '',
+						nlsBaseUrl: openVsx + '/vscode/unpkg/{publisher}/{name}/{version}/extension',
+						publisherUrl: ''
+					};
+				})()
 			};
 		</script>
-		<script>
-		</script>
+		<script></script>
 		<script src="/builtin-extensions.js"></script>
 		<script type="module" src="/src/main.ts" defer></script>
 		<style>

--- a/src/vs/workbench/sidexNullServices.ts
+++ b/src/vs/workbench/sidexNullServices.ts
@@ -6,7 +6,16 @@
 import { InstantiationType, registerSingleton } from '../platform/instantiation/common/extensions.js';
 import { createDecorator } from '../platform/instantiation/common/instantiation.js';
 import { Emitter, Event } from '../base/common/event.js';
+import { IWorkbenchIssueService } from '../workbench/contrib/issue/common/issue.js';
 
+class NullWorkbenchIssueService implements IWorkbenchIssueService {
+	readonly _serviceBrand: undefined;
+	openReporter(_dataOverrides?: any): Promise<void> {
+		return Promise.resolve();
+	}
+}
+
+registerSingleton(IWorkbenchIssueService, NullWorkbenchIssueService, InstantiationType.Delayed);
 // --- IAccessibleViewService ---
 const IAccessibleViewService = createDecorator<IAccessibleViewService>('accessibleViewService');
 interface IAccessibleViewService {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,122 +3,136 @@ import * as path from 'path';
 import { nlsPlugin } from './scripts/vite-plugin-nls';
 
 function quietMissingSourceMaps() {
-  const skip = [/\/vscode-textmate\/.*\.js\.map$/];
-  return {
-    name: 'sidex-quiet-missing-source-maps',
-    configureServer(server: import('vite').ViteDevServer) {
-      server.middlewares.use((req, res, next) => {
-        const url = req.url ?? '';
-        if (skip.some((re) => re.test(url))) {
-          res.statusCode = 204;
-          res.end();
-          return;
-        }
-        next();
-      });
-    },
-  };
+	const skip = [/\/vscode-textmate\/.*\.js\.map$/];
+	return {
+		name: 'sidex-quiet-missing-source-maps',
+		configureServer(server: import('vite').ViteDevServer) {
+			server.middlewares.use((req, res, next) => {
+				const url = req.url ?? '';
+				if (skip.some(re => re.test(url))) {
+					res.statusCode = 204;
+					res.end();
+					return;
+				}
+				next();
+			});
+		}
+	};
 }
 
 export default defineConfig({
-  clearScreen: false,
-  assetsInclude: ['**/*.wasm', '**/*.json', '**/*.tmLanguage.json'],
-  publicDir: 'public',
-  plugins: [nlsPlugin(), quietMissingSourceMaps()],
-  server: {
-    port: 1420,
-    strictPort: true,
-    watch: {
-      ignored: ['**/src-tauri/**'],
-    },
-  },
-  envPrefix: ['VITE_', 'TAURI_'],
-  resolve: {
-    alias: {
-      'vs': path.resolve(__dirname, 'src/vs'),
-    },
-  },
-  build: {
-    target: ['es2022', 'chrome100', 'safari15'],
-    minify: 'esbuild',
-    sourcemap: false,
-    cssCodeSplit: true,
-    chunkSizeWarningLimit: 5000,
-    rollupOptions: {
-      input: {
-        index: path.resolve(__dirname, 'index.html'),
-        textMateWorker: path.resolve(__dirname, 'src/vs/workbench/services/textMate/browser/backgroundTokenization/worker/textMateTokenizationWorker.workerMain.ts'),
-        editorWorker: path.resolve(__dirname, 'src/vs/editor/common/services/editorWebWorkerMain.ts'),
-        extensionHostWorker: path.resolve(__dirname, 'src/vs/workbench/api/worker/extensionHostWorkerMain.ts'),
-      },
-      output: {
-        entryFileNames: (chunkInfo) => {
-          if (chunkInfo.name === 'editorWorker') {
-            return 'assets/editorWorker.js';
-          }
-          if (chunkInfo.name === 'textMateWorker') {
-            return 'assets/textMateWorker.js';
-          }
-          if (chunkInfo.name === 'extensionHostWorker') {
-            return 'assets/extensionHostWorker.js';
-          }
-          return 'assets/[name]-[hash].js';
-        },
-        chunkFileNames: 'assets/[name]-[hash].js',
-        assetFileNames: (assetInfo) => {
-          if ((assetInfo.name ?? '').endsWith('.ts')) {
-            const base = (assetInfo.name ?? 'asset').slice(0, -3);
-            return `assets/${base}-[hash].js`;
-          }
-          return 'assets/[name]-[hash][extname]';
-        },
-        manualChunks(id, { getModuleInfo }) {
-          const isWorkerDep = (moduleId: string, visited = new Set<string>()): boolean => {
-            if (visited.has(moduleId)) return false;
-            visited.add(moduleId);
-            const info = getModuleInfo(moduleId);
-            if (!info) return false;
-            if (info.isEntry && (moduleId.includes('WorkerMain') || moduleId.includes('workerMain'))) {
-              return true;
-            }
-            for (const importer of info.importers) {
-              if (isWorkerDep(importer, visited)) return true;
-            }
-            return false;
-          };
+	clearScreen: false,
+	assetsInclude: ['**/*.wasm', '**/*.json', '**/*.tmLanguage.json'],
+	publicDir: 'public',
+	plugins: [nlsPlugin(), quietMissingSourceMaps()],
+	server: {
+		port: 1420,
+		strictPort: true,
+		watch: {
+			ignored: ['**/src-tauri/**']
+		},
+		proxy: {
+			'/open-vsx-proxy': {
+				target: 'https://open-vsx.org',
+				changeOrigin: true,
+				rewrite: path => path.replace(/^\/open-vsx-proxy/, ''),
+				secure: true
+			}
+		}
+	},
+	envPrefix: ['VITE_', 'TAURI_'],
+	resolve: {
+		alias: {
+			vs: path.resolve(__dirname, 'src/vs')
+		}
+	},
+	build: {
+		target: ['es2022', 'chrome100', 'safari15'],
+		minify: 'esbuild',
+		sourcemap: false,
+		cssCodeSplit: true,
+		chunkSizeWarningLimit: 5000,
+		rollupOptions: {
+			input: {
+				index: path.resolve(__dirname, 'index.html'),
+				textMateWorker: path.resolve(
+					__dirname,
+					'src/vs/workbench/services/textMate/browser/backgroundTokenization/worker/textMateTokenizationWorker.workerMain.ts'
+				),
+				editorWorker: path.resolve(__dirname, 'src/vs/editor/common/services/editorWebWorkerMain.ts'),
+				extensionHostWorker: path.resolve(__dirname, 'src/vs/workbench/api/worker/extensionHostWorkerMain.ts')
+			},
+			output: {
+				entryFileNames: chunkInfo => {
+					if (chunkInfo.name === 'editorWorker') {
+						return 'assets/editorWorker.js';
+					}
+					if (chunkInfo.name === 'textMateWorker') {
+						return 'assets/textMateWorker.js';
+					}
+					if (chunkInfo.name === 'extensionHostWorker') {
+						return 'assets/extensionHostWorker.js';
+					}
+					return 'assets/[name]-[hash].js';
+				},
+				chunkFileNames: 'assets/[name]-[hash].js',
+				assetFileNames: assetInfo => {
+					if ((assetInfo.name ?? '').endsWith('.ts')) {
+						const base = (assetInfo.name ?? 'asset').slice(0, -3);
+						return `assets/${base}-[hash].js`;
+					}
+					return 'assets/[name]-[hash][extname]';
+				},
+				manualChunks(id, { getModuleInfo }) {
+					const isWorkerDep = (moduleId: string, visited = new Set<string>()): boolean => {
+						if (visited.has(moduleId)) return false;
+						visited.add(moduleId);
+						const info = getModuleInfo(moduleId);
+						if (!info) return false;
+						if (info.isEntry && (moduleId.includes('WorkerMain') || moduleId.includes('workerMain'))) {
+							return true;
+						}
+						for (const importer of info.importers) {
+							if (isWorkerDep(importer, visited)) return true;
+						}
+						return false;
+					};
 
-          if (isWorkerDep(id)) {
-            return undefined;
-          }
+					if (isWorkerDep(id)) {
+						return undefined;
+					}
 
-          if (id.endsWith('/vs/nls.ts') || id.endsWith('/vs/nls.js')) {
-            return 'nls';
-          }
-          if (
-            id.includes('/vs/base/') ||
-            id.endsWith('/vs/amdX.ts') || id.endsWith('/vs/amdX.js') ||
-            id.endsWith('/vs/sidex-bridge.ts') || id.endsWith('/vs/sidex-bridge.js') ||
-            id.includes('xterm') || id.includes('/terminal/') ||
-            (id.includes('/vs/editor/') && !id.includes('/workbench/')) ||
-            id.includes('/vs/platform/')
-          ) {
-            return 'core';
-          }
-        },
-      },
-    },
-  },
-  optimizeDeps: {
-    include: ['vscode-textmate', 'vscode-oniguruma'],
-    exclude: ['@tauri-apps/api'],
-  },
-  worker: {
-    format: 'es',
-    rollupOptions: {
-      output: {
-        entryFileNames: 'workers/[name]-[hash].js',
-        chunkFileNames: 'workers/[name]-[hash].js',
-      },
-    },
-  },
+					if (id.endsWith('/vs/nls.ts') || id.endsWith('/vs/nls.js')) {
+						return 'nls';
+					}
+					if (
+						id.includes('/vs/base/') ||
+						id.endsWith('/vs/amdX.ts') ||
+						id.endsWith('/vs/amdX.js') ||
+						id.endsWith('/vs/sidex-bridge.ts') ||
+						id.endsWith('/vs/sidex-bridge.js') ||
+						id.includes('xterm') ||
+						id.includes('/terminal/') ||
+						(id.includes('/vs/editor/') && !id.includes('/workbench/')) ||
+						id.includes('/vs/platform/')
+					) {
+						return 'core';
+					}
+				}
+			}
+		}
+	},
+	optimizeDeps: {
+		include: ['vscode-textmate', 'vscode-oniguruma'],
+		exclude: ['@tauri-apps/api']
+	},
+	worker: {
+		format: 'es',
+		rollupOptions: {
+			output: {
+				entryFileNames: 'workers/[name]-[hash].js',
+				chunkFileNames: 'workers/[name]-[hash].js'
+			}
+		}
+	}
 });


### PR DESCRIPTION
## Fix extension installation in dev mode

### Problem

Two separate issues prevent extensions from installing when running `npm run tauri dev` on Windows:

**1. Missing `IWorkbenchIssueService` registration**

When an extension install fails, the workbench tries to show an error action (`PromptExtensionInstallFailureAction`) that depends on `workbenchIssueService`. This service was never registered in SideX, causing the DI container to throw:

```
[createInstance] PromptExtensionInstallFailureAction depends on UNKNOWN service workbenchIssueService.
```

This error is visible on main when attempting to install any extension that fails.

**2. CORS error when fetching extension resources**

In dev mode, the webview runs at `http://localhost:1420`. Open VSX returns `Access-Control-Allow-Origin: https://tauri.localhost`, which doesn't match the dev origin — so the browser blocks all extension resource fetches:

```
Access to fetch at 'https://open-vsx.org/vscode/unpkg/...' from origin 
'http://localhost:1420' has been blocked by CORS policy
```

This prevents any extension from being installed in dev mode.

### Reproduction

1. Clone the repo and run `npm run tauri dev` on Windows
2. Open the Extensions panel and try to install **Prettier**
3. Observe the CORS error in DevTools console
4. Observe the `workbenchIssueService` DI error in the console after the install failure

### Fix

**1. Add `NullWorkbenchIssueService` stub** (`src/vs/workbench/sidexNullServices.ts`)

Registers a no-op implementation of `IWorkbenchIssueService` following the same pattern as the other null services in that file. Satisfies the DI container so the error action can be instantiated.

**2. Proxy Open VSX requests in dev mode** (`vite.config.ts` + `index.html`)

Adds a Vite dev proxy for `/open-vsx-proxy` → `https://open-vsx.org`. The `resourceUrlTemplate` and `nlsBaseUrl` in `index.html` are updated to use the proxy when running locally, avoiding the CORS mismatch.

The dev check uses `window.location.hostname` rather than hardcoding a port, so it works across all local dev environments:

```js
const isDev = ['localhost', '127.0.0.1', '[::1]'].includes(window.location.hostname);
```

Production builds are completely unaffected — they continue to hit Open VSX directly.

### Testing

-  Prettier installs successfully in dev mode after this fix
-  `workbenchIssueService` DI error no longer appears
-  Production URLs unchanged (verified by checking non-localhost hostname path)

### Notes

Also I tried to install Python extension , installation still fails — this is unrelated to these changes. `ms-python` packages are not published on Open VSX, so they 404 regardless.