### PR TITLE
Window Maximize on TitleBar DoubleClick

### DIFF
--- a/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
+++ b/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
@@ -564,7 +564,7 @@ export class BrowserTitlebarPart extends Part implements ITitlebarPart {
 		this.dragRegion = prepend(this.rootContainer, $('div.titlebar-drag-region'));
 		if ((globalThis as any).__SIDEX_TAURI__) {
 			this.dragRegion.style.setProperty('-webkit-app-region', 'no-drag');
-			this.dragRegion.style.pointerEvents = 'none';
+			// this.dragRegion.style.pointerEvents = 'none';
 
 			this._register(
 				addDisposableListener(this.rootContainer, EventType.MOUSE_DOWN, e => {
@@ -573,6 +573,18 @@ export class BrowserTitlebarPart extends Part implements ITitlebarPart {
 						e.preventDefault();
 						import('@tauri-apps/api/window').then(({ getCurrentWindow }) => {
 							getCurrentWindow().startDragging();
+						});
+					}
+				})
+			);
+
+			this._register(
+				addDisposableListener(this.rootContainer, EventType.DBLCLICK, e => {
+					const target = e.target as HTMLElement;
+					if (target === this.dragRegion || target === this.rootContainer) {
+						e.preventDefault();
+						import('@tauri-apps/api/window').then(({ getCurrentWindow }) => {
+							getCurrentWindow().toggleMaximize();
 						});
 					}
 				})


### PR DESCRIPTION
This updates the custom Tauri title bar so double-clicking the draggable title area toggles maximize, matching VS Code-style behavior.

The draggable region now participates in hit-testing (`pointer-events: none` removed), which allows the double-click event to be handled correctly. The existing titlebar part logic is reused for the update.

<img width="1668" height="1080" alt="result" src="https://github.com/user-attachments/assets/9b8b4497-f407-4a41-86cd-f3935c19c716" />

