### PR TITLE
fix(settings): store Linux user data under XDG config

### DIFF
--- a/src-tauri/src/commands/os.rs
+++ b/src-tauri/src/commands/os.rs
@@ -1,5 +1,6 @@
 use serde::Serialize;
 use std::env;
+use std::path::PathBuf;
 
 #[derive(Debug, Serialize)]
 pub struct OsInfo {
@@ -77,13 +78,22 @@ pub fn get_shell() -> String {
 #[allow(clippy::needless_pass_by_value)]
 #[tauri::command]
 pub fn get_user_data_dir(app: tauri::AppHandle) -> Result<String, String> {
+    let user_dir = resolve_user_data_dir(&app)?;
+    std::fs::create_dir_all(&user_dir)
+        .map_err(|e| format!("failed to create UserData dir: {e}"))?;
+    Ok(user_dir.to_string_lossy().to_string())
+}
+
+pub(crate) fn resolve_user_data_dir(app: &tauri::AppHandle) -> Result<PathBuf, String> {
+    #[cfg(target_os = "linux")]
+    if let Some(config_dir) = dirs::config_dir() {
+        return Ok(config_dir.join("SideX").join("UserData"));
+    }
+
     use tauri::Manager;
     let dir = app
         .path()
         .app_data_dir()
         .map_err(|e| format!("failed to resolve app data dir: {e}"))?;
-    let user_dir = dir.join("UserData");
-    std::fs::create_dir_all(&user_dir)
-        .map_err(|e| format!("failed to create UserData dir: {e}"))?;
-    Ok(user_dir.to_string_lossy().to_string())
+    Ok(dir.join("UserData"))
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -456,7 +456,10 @@ pub fn run() {
 
             {
                 let settings_store = app.state::<Arc<SettingsStore>>();
-                let user_settings_path = app_data.join("UserData").join("User").join("settings.json");
+                let user_settings_path = commands::os::resolve_user_data_dir(app.handle())
+                    .expect("failed to resolve user data dir")
+                    .join("User")
+                    .join("settings.json");
                 if user_settings_path.exists() {
                     if let Err(e) = settings_store.load_user(&user_settings_path) {
                         log::warn!("failed to pre-load user settings: {e}");


### PR DESCRIPTION
Closes #52

## Summary
- Store VS Code-style user data on Linux under `$XDG_CONFIG_HOME/SideX/UserData` (normally `~/.config/SideX/UserData`) instead of Tauri app data.
- Reuse the same resolver for the `vscode-userdata:` provider command and startup `settings.json` preload so settings are read from the same location they are written to.
- Keep the existing app-data behavior for Windows/macOS.

## Issue Evidence
- Issue #52 reports that Linux settings are currently found at `~/.local/share/com.siden.sidex/UserData/User/settings.json`.
- Root cause: `get_user_data_dir` used `app.path().app_data_dir()` and `lib.rs` preloaded from the same app-data root.
- After this change, Linux resolves user data to `$XDG_CONFIG_HOME/SideX/UserData`, so `settings.json` is stored at `$XDG_CONFIG_HOME/SideX/UserData/User/settings.json`.

## Verification
- `git diff --check` — passed.
- `rust-analyzer` LSP — blocked: `rust-analyzer` is not installed in this workflow shell.
- `cargo fmt --check` — blocked: `cargo` is not installed in this workflow shell.
- `cargo check --lib` — blocked: `cargo` is not installed in this workflow shell.
- `where.exe cargo` / `where.exe rustc` — confirmed both tools are unavailable in this workflow shell.

## Community Rules Review
- Focused PR for a single issue/concern.
- Followed existing Tauri/Rust command patterns.
- No unauthorized version bump.
- No workflow/tracker/profile files included in the target repo diff.
