### PR TITLE
fix(extensions): register workbench issue service fallback

### DIFF
--- a/src/vs/workbench/sidexNullServices.ts
+++ b/src/vs/workbench/sidexNullServices.ts
@@ -6,6 +6,7 @@
 import { InstantiationType, registerSingleton } from '../platform/instantiation/common/extensions.js';
 import { createDecorator } from '../platform/instantiation/common/instantiation.js';
 import { Emitter, Event } from '../base/common/event.js';
+import { IWorkbenchIssueService } from './contrib/issue/common/issue.js';
 
 // --- IAccessibleViewService ---
 const IAccessibleViewService = createDecorator<IAccessibleViewService>('accessibleViewService');
@@ -18,6 +19,13 @@ class NullAccessibleViewService implements IAccessibleViewService {
 	show() {}
 }
 registerSingleton(IAccessibleViewService, NullAccessibleViewService, InstantiationType.Delayed);
+
+// --- workbenchIssueService ---
+class NullWorkbenchIssueService implements IWorkbenchIssueService {
+	declare readonly _serviceBrand: undefined;
+	async openReporter(): Promise<void> {}
+}
+registerSingleton(IWorkbenchIssueService, NullWorkbenchIssueService, InstantiationType.Delayed);
 
 // --- notebookEditorModelResolverService ---
 const INotebookEditorModelResolverService = createDecorator<INotebookEditorModelResolverService>(


### PR DESCRIPTION
Closes #55

## Summary
- Register a SideX fallback implementation of `IWorkbenchIssueService`.
- Prevent extension install failure handling from crashing with `UNKNOWN service workbenchIssueService`.
- Keep issue reporting as a no-op until SideX adds a full native issue reporter.

## Issue Evidence
- Issue #55 reports extension installation failures with: `[createInstance] $I depends on UNKNOWN service workbenchIssueService`.
- Root cause: `PromptExtensionInstallFailureAction` injects `IWorkbenchIssueService`, but SideX's service bootstrap did not register that service.
- The fix registers the service in `sidexNullServices.ts`, which is already imported by `workbench.common.main.ts` for SideX-specific fallbacks.

## Verification
- LSP diagnostics for `src/vs/workbench/sidexNullServices.ts` — clean.
- `bunx eslint src/vs/workbench/sidexNullServices.ts` — passed.
- `bunx tsc --noEmit` — passed.
- `git diff --check` — passed.

## Community Rules Review
- Focused PR for a single issue/concern.
- Followed existing SideX null-service registration pattern.
- No unauthorized version bump.
- No workflow/tracker/profile files included in the target repo diff.
