### PR TITLE
fix(extensions): ignore VS Code user extension folders

### DIFF
--- a/src-tauri/extension-host/server.cjs
+++ b/src-tauri/extension-host/server.cjs
@@ -135,8 +135,6 @@ function getExtensionSearchPaths() {
     EXTENSIONS_DIR,
     builtinExt,
     path.resolve(process.cwd(), 'dist', 'extensions'),
-    path.join(os.homedir(), '.vscode', 'extensions'),
-    path.join(os.homedir(), '.cursor', 'extensions'),
     path.join(process.cwd(), 'extensions'),
     path.resolve(__dirname, '..', 'extensions'),
     path.resolve(__dirname, '..', '..', 'extensions'),

--- a/src-tauri/src/commands/extension_platform.rs
+++ b/src-tauri/src/commands/extension_platform.rs
@@ -517,9 +517,6 @@ pub fn extension_search_paths(app: &AppHandle) -> Vec<PathBuf> {
         .unwrap_or_else(|_| PathBuf::from("."))
         .join("dist")
         .join("extensions");
-    let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("."));
-    let vscode_user_ext = home.join(".vscode").join("extensions");
-    let cursor_user_ext = home.join(".cursor").join("extensions");
     let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
 
     let rust_ext = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -533,8 +530,6 @@ pub fn extension_search_paths(app: &AppHandle) -> Vec<PathBuf> {
         cursor_app_ext.unwrap_or_default(),
         vscode_app_ext.unwrap_or_default(),
         dist_ext,
-        vscode_user_ext,
-        cursor_user_ext,
         cwd.join("extensions"),
         PathBuf::from(env!("CARGO_MANIFEST_DIR"))
             .join("..")


### PR DESCRIPTION
Closes #50

## Summary
- Stop runtime extension discovery from scanning VS Code's user extension directory (`~/.vscode/extensions`).
- Also stop scanning Cursor's user extension directory (`~/.cursor/extensions`) for the same reason.
- Keep SideX's own extension directory, bundled extension directory, `dist/extensions`, and repository extension fallbacks.

## Issue Evidence
- Issue #50 shows SideX touching a Java runtime under `C:\Users\xxoo\.vscode\extensions\redhat.java-...`.
- Root cause: both Rust-side extension discovery and the Node extension host fallback included `~/.vscode/extensions` in runtime search paths.
- After this change, SideX no longer scans VS Code/Cursor user-installed extensions by default.

## Verification
- `node --check src-tauri/extension-host/server.cjs` — passed.
- `git diff --check` — passed.
- `rust-analyzer` LSP — blocked: `rust-analyzer` is not installed in this workflow shell.
- Rust compile/fmt checks — blocked per repository profile because `cargo` and `rustc` are not installed in this workflow shell.

## Community Rules Review
- Focused PR for a single issue/concern.
- Kept runtime extension-host search roots consistent between Rust and Node fallback paths.
- No unauthorized version bump.
- No workflow/tracker/profile files included in the target repo diff.
