### PR TITLE
fix(editor): add Windows newline keybinding fallback

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -211,6 +211,7 @@ async function boot() {
 	setupMenuActions();
 	setupWindowStateSave();
 	setupNativeWindowDragging();
+	setupWindowsEditorNewlineKeybindings();
 	updateNativeMenuLabels();
 
 	console.log(
@@ -281,6 +282,38 @@ function setupNativeWindowDragging() {
 		},
 		true
 	);
+}
+
+function setupWindowsEditorNewlineKeybindings() {
+	if (!navigator.userAgent.includes('Windows')) {
+		return;
+	}
+
+	window.addEventListener('keydown', event => {
+		if (event.defaultPrevented || event.key !== 'Enter' || !event.ctrlKey || event.altKey || event.metaKey) {
+			return;
+		}
+
+		const target = event.target instanceof HTMLElement ? event.target : document.activeElement;
+		if (!(target instanceof HTMLElement) || !target.closest('.monaco-editor')) {
+			return;
+		}
+
+		const commandService = (
+			window as { __sidex_commandService?: { executeCommand(commandId: string): Promise<unknown> } }
+		).__sidex_commandService;
+		if (!commandService) {
+			return;
+		}
+
+		event.preventDefault();
+		event.stopPropagation();
+
+		const commandId = event.shiftKey ? 'editor.action.insertLineBefore' : 'editor.action.insertLineAfter';
+		commandService.executeCommand(commandId).catch(error => {
+			console.error(`[SideX] Failed to execute ${commandId}:`, error);
+		});
+	});
 }
 
 function setupMenuActions() {


### PR DESCRIPTION
Closes #56

## Summary
- Add a Windows-only fallback for `Ctrl+Enter` and `Ctrl+Shift+Enter` inside Monaco editors.
- Dispatch the existing VS Code commands `editor.action.insertLineAfter` and `editor.action.insertLineBefore` when the normal keybinding path leaves the event unhandled.
- Guard the fallback so it only runs with focus inside `.monaco-editor` and does not interfere when VS Code already handled the key event.

## Issue Evidence
- Issue #56 reports that `Ctrl+Enter` and `Ctrl+Shift+Enter` do not work on Win11.
- The standard editor commands and keybindings exist in SideX's imported VS Code editor code, so the issue is likely in event delivery/handling on the Tauri Windows path.
- This change preserves the existing command behavior and only bridges the unhandled Windows key event to those commands.

## Verification
- LSP diagnostics for `src/main.ts` — clean.
- `bunx eslint src/main.ts` — passed.
- `bunx tsc --noEmit` — passed.
- `git diff --check` — passed.

## Community Rules Review
- Focused PR for a single issue/concern.
- Reused existing VS Code editor commands instead of adding custom editing behavior.
- No unauthorized version bump.
- No workflow/tracker/profile files included in the target repo diff.
