### PR TITLE
fix: correct typos (separately, accommodate)

### DIFF
--- a/src/vs/workbench/contrib/files/browser/explorerViewlet.ts
+++ b/src/vs/workbench/contrib/files/browser/explorerViewlet.ts
@@ -240,7 +240,7 @@ export class ExplorerViewPaneContainer extends ViewPaneContainer {
 							const config = this.configurationService.getValue<IFilesConfiguration>();
 							if (config.workbench?.editor?.enablePreview) {
 								// delay open editors view when preview is enabled
-								// to accomodate for the user doing a double click
+								// to accommodate for the user doing a double click
 								// to pin the editor.
 								// without this delay a double click would be not
 								// possible because the next element would move

--- a/src/vs/workbench/contrib/files/browser/views/explorerViewer.ts
+++ b/src/vs/workbench/contrib/files/browser/views/explorerViewer.ts
@@ -1949,7 +1949,7 @@ export class FileDragAndDrop implements ITreeDragAndDrop<ExplorerItem> {
 			if (
 				items.some(source => {
 					if (source.isRoot) {
-						return false; // Root folders are handled seperately
+						return false; // Root folders are handled separately
 					}
 
 					if (this.uriIdentityService.extUri.isEqual(source.resource, target.resource)) {

--- a/src/vs/workbench/services/extensions/common/extensionRunningLocationTracker.ts
+++ b/src/vs/workbench/services/extensions/common/extensionRunningLocationTracker.ts
@@ -163,7 +163,7 @@ export class ExtensionRunningLocationTracker {
 		// When doing extension host debugging, we will ignore the configured affinity
 		// because we can currently debug a single extension host
 		if (!this._environmentService.isExtensionDevelopment) {
-			// Go through each configured affinity and try to accomodate it
+			// Go through each configured affinity and try to accommodate it
 			const configuredAffinities = this._configurationService.getValue<{ [extensionId: string]: number } | undefined>('extensions.experimental.affinity') || {};
 			const configuredExtensionIds = Object.keys(configuredAffinities);
 			const configuredAffinityToResultingAffinity = new Map<number, number>();


### PR DESCRIPTION
Corrected typos: 'seperately' -> 'separately', 'accomodate' -> 'accommodate' in 3 files.