### PR TITLE
fix(terminal): build broken on Linux/macOS — resolve_git_bash gated by cfg but called unconditionally

### DIFF
--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -482,6 +482,7 @@ pub fn get_available_shells() -> Vec<ShellInfo> {
         let mut seen = std::collections::HashSet::new();
         let mut shells = Vec::new();
 
+        #[cfg(target_os = "windows")]
         if let Some(resolved_path) = resolve_git_bash() {
             seen.insert("Git Bash".to_string());
             shells.push(ShellInfo {


### PR DESCRIPTION
## Problem

`main` fails to compile on Linux and macOS since 108e4bb4:

```
error[E0425]: cannot find function `resolve_git_bash` in this scope
   --> src-tauri/src/commands/terminal.rs:485:38
    |
485 |         if let Some(resolved_path) = resolve_git_bash() {
    |                                      ^^^^^^^^^^^^^^^^ not found in this scope
```

`resolve_git_bash()` is declared with `#[cfg(target_os = "windows")]`, but `get_available_shells()` calls it inside a **runtime** `if cfg!(target_os = "windows")` block. `cfg!` keeps both branches in the compilation unit on every OS, so on non-Windows targets the symbol doesn't exist.

## Fix

One line: gate the call with a statement-level `#[cfg(target_os = "windows")]`, same pattern already used at the other call site (line 126, in the default-shell resolution path).

## Verification

On Linux (x86_64, rustc 1.95.0):
- `cargo check --workspace` — clean (only pre-existing warnings)
- `cargo build --release` — succeeds, produces working `SideX` binary
- No behavior change on Windows: the statement compiles identically there.