### PR TITLE
Fixes: issue #85 and a minor spelling issue in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ SideX is a port of Visual Studio Code that replaces Electron with [Tauri](https:
 
 ## Why
 
-VSCode's memory useage is almost entirely from its bundled Chromium, not the editor itself. Tauri replaces that with the webview already on your system — WKWebView on macOS, WebView2 on Windows — shared across apps and costing almost nothing extra.
+VSCode's memory usage is almost entirely from its bundled Chromium, not the editor itself. Tauri replaces that with the webview already on your system — WKWebView on macOS, WebView2 on Windows — shared across apps and costing almost nothing extra.
 
 <p align="center">
   <img src="./docs/assets/compare.jpg" alt="SideX 16.4 MB vs Visual Studio Code 797.8 MB" width="760">

--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -471,7 +471,8 @@ pub fn check_shell_exists(path: String) -> bool {
 #[tauri::command]
 #[allow(clippy::too_many_lines)]
 pub fn get_available_shells() -> Vec<ShellInfo> {
-    if cfg!(target_os = "windows") {
+    #[cfg(target_os = "windows")]
+    {
         let candidates: &[(&str, &str)] = &[
             ("PowerShell", "powershell.exe"),
             ("PowerShell Core", "pwsh.exe"),


### PR DESCRIPTION
The issue #85 was fixed with the change in src/commands/terminal.rs

replaced:
```if cfg!(target_os = "windows")```
with:
```#[cfg(target_os = "windows")]```

this changes the check from runtime one to compile time one, skips the check entirely for non-windows devices

also fixes a minor spelling issue in the README.md:
useage -> usage