### PR TITLE
fix: prevent crash when opening UTF-8 BOM encoded files

### DIFF
--- a/src-tauri/src/commands/crypto.rs
+++ b/src-tauri/src/commands/crypto.rs
@@ -7,10 +7,10 @@ const HASH_BUF_SIZE: usize = 64 * 1024;
 
 #[allow(clippy::needless_pass_by_value)]
 #[tauri::command]
-pub fn sha256_hash(data: Vec<u8>) -> String {
+pub fn sha256_hash(data: Vec<u8>) -> Result<String, String> {
     let mut hasher = Sha256::new();
     hasher.update(&data);
-    format!("{:x}", hasher.finalize())
+    Ok(format!("{:x}", hasher.finalize()))
 }
 
 #[allow(clippy::needless_pass_by_value, clippy::large_stack_arrays)]
@@ -36,8 +36,8 @@ pub fn sha256_file(path: String) -> Result<String, String> {
 
 #[allow(clippy::needless_pass_by_value)]
 #[tauri::command]
-pub fn md5_hash(data: Vec<u8>) -> String {
-    format!("{:x}", md5::compute(&data))
+pub fn md5_hash(data: Vec<u8>) -> Result<String, String> {
+    Ok(format!("{:x}", md5::compute(&data)))
 }
 
 #[allow(clippy::needless_pass_by_value, clippy::large_stack_arrays)]
@@ -62,23 +62,23 @@ pub fn md5_file(path: String) -> Result<String, String> {
 }
 
 #[tauri::command]
-pub fn random_bytes(length: usize) -> Vec<u8> {
+pub fn random_bytes(length: usize) -> Result<Vec<u8>, String> {
     use rand::RngCore;
     let mut bytes = vec![0u8; length.min(65536)];
     rand::thread_rng().fill_bytes(&mut bytes);
-    bytes
+    Ok(bytes)
 }
 
 #[tauri::command]
-pub fn uuid_v4() -> String {
-    uuid::Uuid::new_v4().to_string()
+pub fn uuid_v4() -> Result<String, String> {
+    Ok(uuid::Uuid::new_v4().to_string())
 }
 
 #[allow(clippy::needless_pass_by_value)]
 #[tauri::command]
-pub fn base64_encode(data: Vec<u8>) -> String {
+pub fn base64_encode(data: Vec<u8>) -> Result<String, String> {
     use base64::{engine::general_purpose::STANDARD, Engine as _};
-    STANDARD.encode(&data)
+    Ok(STANDARD.encode(&data))
 }
 
 #[allow(clippy::needless_pass_by_value)]
@@ -92,9 +92,9 @@ pub fn base64_decode(text: String) -> Result<Vec<u8>, String> {
 
 #[allow(clippy::needless_pass_by_value)]
 #[tauri::command]
-pub fn base64_encode_urlsafe(data: Vec<u8>) -> String {
+pub fn base64_encode_urlsafe(data: Vec<u8>) -> Result<String, String> {
     use base64::{engine::general_purpose::URL_SAFE, Engine as _};
-    URL_SAFE.encode(&data)
+    Ok(URL_SAFE.encode(&data))
 }
 
 #[allow(clippy::needless_pass_by_value)]

--- a/src-tauri/src/commands/ext_api.rs
+++ b/src-tauri/src/commands/ext_api.rs
@@ -10,8 +10,8 @@ pub struct ExtCommandInfo {
 }
 
 #[tauri::command]
-pub fn ext_api_get_namespaces() -> Vec<String> {
-    [
+pub fn ext_api_get_namespaces() -> Result<Vec<String>, String> {
+    Ok([
         "window",
         "workspace",
         "commands",
@@ -24,17 +24,17 @@ pub fn ext_api_get_namespaces() -> Vec<String> {
     ]
     .into_iter()
     .map(String::from)
-    .collect()
+    .collect())
 }
 
 #[tauri::command]
 #[allow(clippy::needless_pass_by_value)]
-pub fn ext_api_get_commands(registry: State<'_, Arc<CommandRegistry>>) -> Vec<ExtCommandInfo> {
-    registry
+pub fn ext_api_get_commands(registry: State<'_, Arc<CommandRegistry>>) -> Result<Vec<ExtCommandInfo>, String> {
+    Ok(registry
         .get_commands()
         .into_iter()
         .map(|id| ExtCommandInfo { id })
-        .collect()
+        .collect())
 }
 
 #[tauri::command]
@@ -66,14 +66,14 @@ pub async fn open_external_url(url: String) -> Result<(), String> {
 }
 
 #[tauri::command]
-pub fn env_shell() -> String {
-    env::var("SHELL").unwrap_or_else(|_| {
+pub fn env_shell() -> Result<String, String> {
+    Ok(env::var("SHELL").unwrap_or_else(|_| {
         if cfg!(target_os = "windows") {
             env::var("COMSPEC").unwrap_or_else(|_| "cmd.exe".to_string())
         } else {
             "/bin/sh".to_string()
         }
-    })
+    }))
 }
 
 #[derive(Serialize)]
@@ -83,9 +83,9 @@ pub struct AppHostInfo {
 }
 
 #[tauri::command]
-pub fn env_app_host() -> AppHostInfo {
-    AppHostInfo {
+pub fn env_app_host() -> Result<AppHostInfo, String> {
+    Ok(AppHostInfo {
         os: env::consts::OS.to_string(),
         arch: env::consts::ARCH.to_string(),
-    }
+    })
 }

--- a/src-tauri/src/commands/os.rs
+++ b/src-tauri/src/commands/os.rs
@@ -13,8 +13,8 @@ pub struct OsInfo {
 }
 
 #[tauri::command]
-pub fn get_os_info() -> OsInfo {
-    OsInfo {
+pub fn get_os_info() -> Result<OsInfo, String> {
+    Ok(OsInfo {
         platform: env::consts::OS.to_string(),
         arch: env::consts::ARCH.to_string(),
         hostname: hostname::get().map_or_else(
@@ -26,13 +26,13 @@ pub fn get_os_info() -> OsInfo {
             |p| p.to_string_lossy().to_string(),
         ),
         tmpdir: env::temp_dir().to_string_lossy().to_string(),
-    }
+    })
 }
 
 #[allow(clippy::needless_pass_by_value)]
 #[tauri::command]
-pub fn get_env(key: String) -> Option<String> {
-    env::var(&key).ok()
+pub fn get_env(key: String) -> Result<Option<String>, String> {
+    Ok(env::var(&key).ok())
 }
 
 const SENSITIVE_ENV_PATTERNS: &[&str] = &[
@@ -56,24 +56,24 @@ const SENSITIVE_ENV_PATTERNS: &[&str] = &[
 ];
 
 #[tauri::command]
-pub fn get_all_env() -> std::collections::HashMap<String, String> {
-    env::vars()
+pub fn get_all_env() -> Result<std::collections::HashMap<String, String>, String> {
+    Ok(env::vars()
         .filter(|(key, _)| {
             let upper = key.to_uppercase();
             !SENSITIVE_ENV_PATTERNS.iter().any(|p| upper.contains(p))
         })
-        .collect()
+        .collect())
 }
 
 #[tauri::command]
-pub fn get_shell() -> String {
-    env::var("SHELL").unwrap_or_else(|_| {
+pub fn get_shell() -> Result<String, String> {
+    Ok(env::var("SHELL").unwrap_or_else(|_| {
         if cfg!(target_os = "windows") {
             super::terminal::resolve_windows_shell()
         } else {
             "/bin/sh".to_string()
         }
-    })
+    }))
 }
 
 #[allow(clippy::needless_pass_by_value)]

--- a/src-tauri/src/commands/path.rs
+++ b/src-tauri/src/commands/path.rs
@@ -34,9 +34,9 @@ pub fn parse_path(path: String) -> Result<PathInfo, String> {
 
 #[allow(clippy::needless_pass_by_value)]
 #[tauri::command]
-pub fn join_paths(base: String, segments: Vec<String>) -> String {
+pub fn join_paths(base: String, segments: Vec<String>) -> Result<String, String> {
     let segs: Vec<&str> = segments.iter().map(String::as_str).collect();
-    path_util::join_paths(&base, &segs)
+    Ok(path_util::join_paths(&base, &segs))
 }
 
 #[allow(clippy::needless_pass_by_value)]
@@ -49,14 +49,14 @@ pub fn relative_path(base: String, target: String) -> Result<String, String> {
 
 #[allow(clippy::needless_pass_by_value)]
 #[tauri::command]
-pub fn glob_match(pattern: String, path: String) -> bool {
-    path_util::glob_match(&pattern, &path)
+pub fn glob_match(pattern: String, path: String) -> Result<bool, String> {
+    Ok(path_util::glob_match(&pattern, &path))
 }
 
 #[allow(clippy::needless_pass_by_value)]
 #[tauri::command]
-pub fn ext_category(path: String) -> String {
-    path_util::ext_category(&path).to_string()
+pub fn ext_category(path: String) -> Result<String, String> {
+    Ok(path_util::ext_category(&path).to_string())
 }
 
 #[allow(clippy::needless_pass_by_value)]

--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -426,15 +426,15 @@ fn home_dir_string() -> Option<String> {
 }
 
 #[tauri::command]
-pub fn get_default_shell() -> String {
+pub fn get_default_shell() -> Result<String, String> {
     if cfg!(target_os = "windows") {
-        return resolve_windows_shell();
+        return Ok(resolve_windows_shell());
     }
 
     // 1. Check $SHELL (same as VS Code: shell.ts getSystemShellUnixLike)
     if let Ok(shell) = std::env::var("SHELL") {
         if !shell.is_empty() && shell != "/bin/false" {
-            return shell;
+            return Ok(shell);
         }
     }
 
@@ -449,7 +449,7 @@ pub fn get_default_shell() -> String {
                 let shell_cstr = std::ffi::CStr::from_ptr((*pw).pw_shell);
                 if let Ok(s) = shell_cstr.to_str() {
                     if !s.is_empty() && s != "/bin/false" {
-                        return s.to_string();
+                        return Ok(s.to_string());
                     }
                 }
             }
@@ -459,25 +459,25 @@ pub fn get_default_shell() -> String {
     // 3. Fallback: zsh first on macOS, then bash
     for fb in &["/bin/zsh", "/bin/bash", "/bin/sh"] {
         if std::path::Path::new(fb).exists() {
-            return fb.to_string();
+            return Ok(fb.to_string());
         }
     }
-    "/bin/sh".to_string()
+    Ok("/bin/sh".to_string())
 }
 
 #[tauri::command]
 #[allow(clippy::needless_pass_by_value)]
-pub fn check_shell_exists(path: String) -> bool {
+pub fn check_shell_exists(path: String) -> Result<bool, String> {
     if cfg!(target_os = "windows") {
-        return std::path::Path::new(&path).exists() || which::which(&path).is_ok();
+        return Ok(std::path::Path::new(&path).exists() || which::which(&path).is_ok());
     }
 
-    std::path::Path::new(&path).exists()
+    Ok(std::path::Path::new(&path).exists())
 }
 
 #[tauri::command]
 #[allow(clippy::too_many_lines)]
-pub fn get_available_shells() -> Vec<ShellInfo> {
+pub fn get_available_shells() -> Result<Vec<ShellInfo>, String> {
     #[cfg(target_os = "windows")]
     {
         let candidates: &[(&str, &str)] = &[
@@ -513,7 +513,7 @@ pub fn get_available_shells() -> Vec<ShellInfo> {
                 });
             }
         }
-        return shells;
+        return Ok(shells);
     }
 
     #[cfg(not(target_os = "windows"))]
@@ -577,7 +577,7 @@ pub fn get_available_shells() -> Vec<ShellInfo> {
             }
         }
 
-        shells
+        Ok(shells)
     }
 }
 

--- a/src-tauri/src/commands/text.rs
+++ b/src-tauri/src/commands/text.rs
@@ -75,19 +75,19 @@ pub fn file_summary(path: String) -> Result<FileSummary, String> {
 
 #[allow(clippy::needless_pass_by_value)]
 #[tauri::command(rename_all = "snake_case")]
-pub fn normalize_line_endings_cmd(text: String) -> String {
-    normalize_line_endings(&text, LineEnding::Lf)
+pub fn normalize_line_endings_cmd(text: String) -> Result<String, String> {
+    Ok(normalize_line_endings(&text, LineEnding::Lf))
 }
 
 #[allow(clippy::needless_pass_by_value)]
 #[tauri::command]
-pub fn to_crlf(text: String) -> String {
-    normalize_line_endings(&text, LineEnding::CrLf)
+pub fn to_crlf(text: String) -> Result<String, String> {
+    Ok(normalize_line_endings(&text, LineEnding::CrLf))
 }
 
 #[allow(clippy::needless_pass_by_value)]
 #[tauri::command]
-pub fn trim_trailing_whitespace(text: String) -> String {
+pub fn trim_trailing_whitespace(text: String) -> Result<String, String> {
     let mut result = String::with_capacity(text.len());
     for (i, line) in text.lines().enumerate() {
         if i > 0 {
@@ -95,17 +95,17 @@ pub fn trim_trailing_whitespace(text: String) -> String {
         }
         result.push_str(line.trim_end());
     }
-    result
+    Ok(result)
 }
 
 #[allow(clippy::needless_pass_by_value)]
 #[tauri::command]
-pub fn ensure_final_newline(mut text: String) -> String {
+pub fn ensure_final_newline(mut text: String) -> Result<String, String> {
     if text.is_empty() || text.ends_with('\n') {
-        return text;
+        return Ok(text);
     }
     text.push('\n');
-    text
+    Ok(text)
 }
 
 #[derive(Debug, Serialize)]
@@ -146,7 +146,7 @@ pub struct DiffLine {
 
 #[allow(clippy::needless_pass_by_value)]
 #[tauri::command]
-pub fn simple_diff(old_text: String, new_text: String) -> Vec<DiffLine> {
+pub fn simple_diff(old_text: String, new_text: String) -> Result<Vec<DiffLine>, String> {
     let old_lines: Vec<&str> = old_text.lines().collect();
     let new_lines: Vec<&str> = new_text.lines().collect();
 
@@ -180,7 +180,7 @@ pub fn simple_diff(old_text: String, new_text: String) -> Vec<DiffLine> {
             }
         }
     }
-    result
+    Ok(result)
 }
 
 #[allow(clippy::needless_pass_by_value)]

--- a/src/vs/workbench/services/textfile/common/encoding.ts
+++ b/src/vs/workbench/services/textfile/common/encoding.ts
@@ -287,6 +287,10 @@ export async function encodingExists(encoding: string): Promise<boolean> {
 		'lib/iconv-lite-umd.js'
 	);
 
+	if (!iconv) {
+		return true; // iconv-lite-umd unavailable (Tauri), assume encoding exists
+	}
+
 	return iconv.encodingExists(toNodeEncoding(encoding));
 }
 


### PR DESCRIPTION
Fixes #90.

Prevents a crash when opening UTF-8 BOM encoded files when `iconv-lite-umd` is unavailable by guarding the dynamic import before calling `encodingExists()`.