### PR TITLE
fix: new window creation, IPC routing, and native shortcuts

### DIFF
--- a/.agent-logs/2026-07-13_18-18_fix-new-window-routing.md
+++ b/.agent-logs/2026-07-13_18-18_fix-new-window-routing.md
@@ -1,0 +1,30 @@
+## Goal
+Fix the "New Window" action in SideX so that it creates a real, functional OS-level window, and ensure all native macOS shortcuts (like Cmd+`) and native menus work correctly in the new window.
+
+## User Feedback & Decisions
+- User pointed out "New Window" simply navigates the current window.
+- User noted that native menus and shortcuts didn't work in the new window.
+- User noted that the newly spawned window's IPC features (like file dialogs) were completely non-functional.
+- User noted Cmd+` was swallowed and did not cycle windows.
+- Decided to revert pnpm artifacts since the project uses npm.
+
+## Changes Made
+- `src/main.ts`: Updated `workspaceProvider.open` to invoke Tauri's `create_window` command when `forceNewWindow` (via `reuse: false`) is requested.
+- `src-tauri/capabilities/default.json`: Expanded IPC permissions from `["main"]` to `["*"]` so dynamically spawned windows can execute commands.
+- `src-tauri/src/lib.rs`: 
+  - Updated `on_menu_event` to dispatch events to the currently focused window instead of hardcoding the `"main"` window.
+  - Used `tauri::menu::WINDOW_SUBMENU_ID` for the Window menu so macOS recognizes it.
+  - Added a native `CmdOrCtrl+\`` accelerator to "Cycle Through Windows" to prevent the webview from swallowing the shortcut, and handled the window cycling logic natively in Rust by sorting window labels.
+
+## What Worked
+- New windows spawn correctly using Tauri's native window APIs.
+- The active window now accurately receives and executes native menu events.
+- IPC capabilities are correctly inherited by new windows.
+- Cmd+` successfully cycles between windows using native OS-level interception.
+
+## What Didn't Work / Known Issues
+- None at this time.
+
+## Architecture Notes
+- Tauri v2 strictly enforces IPC capabilities per window. Using `["*"]` in the capabilities JSON is necessary if dynamically spawned windows need to access the Tauri API.
+- VS Code / Monaco Editor aggressively swallows `Cmd+\``. To override this in a Tauri context, a native menu accelerator must be registered to intercept it before the webview event loop processes it.

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -2,7 +2,7 @@
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
   "description": "SideX IDE permissions",
-  "windows": ["main"],
+  "windows": ["*"],
   "permissions": [
     "core:default",
     "core:webview:allow-internal-toggle-devtools",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -317,9 +317,17 @@ fn build_menu(app: &tauri::AppHandle) -> tauri::Result<Menu<tauri::Wry>> {
         )
         .build()?;
 
-    let window_menu = SubmenuBuilder::with_id(app, "window_menu", "Window")
+    let cycle_windows_item = MenuItemBuilder::with_id("cycle_windows", "Cycle Through Windows")
+        .accelerator("CmdOrCtrl+`")
+        .build(app)?;
+
+    let window_menu = SubmenuBuilder::with_id(app, tauri::menu::WINDOW_SUBMENU_ID, "Window")
         .item(&PredefinedMenuItem::minimize(app, None)?)
         .item(&PredefinedMenuItem::maximize(app, None)?)
+        .item(&PredefinedMenuItem::separator(app)?)
+        .item(&cycle_windows_item)
+        .item(&PredefinedMenuItem::separator(app)?)
+        .item(&PredefinedMenuItem::close_window(app, None)?)
         .build()?;
 
     let help_menu = SubmenuBuilder::with_id(app, "help_menu", "Help")
@@ -511,9 +519,37 @@ pub fn run() {
         })
         .on_menu_event(|app, event| {
             let id = event.id().0.as_str();
-            if let Some(window) = app.get_webview_window("main") {
-                let escaped = id.replace('\\', "\\\\").replace('\'', "\\'");
-                let _ = window.eval(format!(
+
+            if id == "cycle_windows" {
+                let mut windows: Vec<_> = app.webview_windows().into_values().collect();
+                if windows.is_empty() {
+                    return;
+                }
+                
+                windows.sort_by_key(|w| w.label().to_string());
+                
+                let mut focused_index = None;
+                for (i, window) in windows.iter().enumerate() {
+                    if window.is_focused().unwrap_or(false) {
+                        focused_index = Some(i);
+                        break;
+                    }
+                }
+                
+                let next_index = focused_index.map(|i| (i + 1) % windows.len()).unwrap_or(0);
+                if let Some(next_window) = windows.get(next_index) {
+                    let _ = next_window.set_focus();
+                }
+                return;
+            }
+
+            let escaped = id.replace('\\', "\\\\").replace('\'', "\\'");
+            let windows = app.webview_windows();
+            let target = windows.values().find(|w| w.is_focused().unwrap_or(false))
+                .or_else(|| windows.get("main"));
+                
+            if let Some(window) = target {
+                let _ = window.eval(&format!(
                     "window.dispatchEvent(new CustomEvent('sidex-native-menu', {{ detail: '{escaped}' }}))"
                 ));
             }

--- a/src/main.ts
+++ b/src/main.ts
@@ -107,11 +107,36 @@ async function boot() {
 			workspace,
 			trusted: true,
 			open: async (_workspace: any, _options: any) => {
-				// When VSCode asks to open a new workspace, reload with the folder param
+				const reuseWindow = _options?.reuse === true;
+				
+				let targetUrl = new URL(window.location.href);
 				if (_workspace && 'folderUri' in _workspace) {
-					navigateToFolder(_workspace.folderUri.toString());
+					targetUrl.searchParams.set('folder', _workspace.folderUri.toString());
+				} else if (_workspace && 'workspaceUri' in _workspace) {
+					targetUrl.searchParams.set('folder', _workspace.workspaceUri.toString());
+				} else {
+					targetUrl.searchParams.delete('folder');
 				}
-				return true;
+
+				if (reuseWindow) {
+					window.location.href = targetUrl.toString();
+					return true;
+				} else {
+					try {
+						const { invoke } = await import('@tauri-apps/api/core');
+						const label = `sidex-${Date.now()}-${Math.floor(Math.random() * 1000)}`;
+						
+						await invoke('create_window', {
+							label,
+							title: 'SideX',
+							url: targetUrl.toString()
+						});
+						return true;
+					} catch (e) {
+						console.error('[SideX] Failed to open new window:', e);
+						return false;
+					}
+				}
 			}
 		},
 		windowIndicator: {


### PR DESCRIPTION
## Description
Fixes issues where the "New Window" action failed to correctly spawn OS-level windows in Tauri and prevented newly spawned windows from accessing IPC capabilities.

## Changes
* **main.ts**: Modified `workspaceProvider.open` to handle `reuse: false` correctly by calling Tauri's `create_window` IPC command natively, instead of merely updating the window location.
* **default.json**: Expanded IPC capability `windows` mask to `["*"]` so dynamically spawned windows correctly inherit IPC permissions from the main window.
* **lib.rs**: 
  * Re-wired native menu dispatcher to route events to the `is_focused` window instead of hardcoding `"main"`.
  * Updated `window_menu` to use `tauri::menu::WINDOW_SUBMENU_ID` to signal to macOS to properly attach native window menu behaviors.
  * Explicitly bound a `Cycle Through Windows` command to `CmdOrCtrl+`` to preempt aggressive webview event-swallowing, allowing predictable cross-window cycling natively via Rust.

## Testing
- Spawning a "New Window" creates a completely separate Tauri window.
- Menu actions (like Open File) execute accurately in the actively focused window.
- Shortcuts like `Cmd+`` effectively cycle between instances natively without frontend interference.