### PR TITLE
fix (issue-112): strip launching shell state from terminal env

### DIFF
--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -37,6 +37,92 @@ struct TerminalExitEvent {
     exit_code: i32,
 }
 
+// Environment variables that describe the shell session SideX was launched from.
+// They only exist when the app is started from a terminal, so a terminal opened
+// after a CLI launch behaves differently from one opened after a menu launch,
+// where the app starts from the clean desktop session environment instead.
+//
+// VTE_VERSION is the one confirmed to break a real setup (issue #112): a
+// gnome-terminal launch leaks it into the app, and the spawned login shell then
+// runs /etc/profile.d/vte-2.91.sh. That script appends to PROMPT_COMMAND when it
+// is an array and overwrites it otherwise, and a prompt framework initialised
+// earlier from /etc/profile.d - starship, in the reported setup - leaves it a
+// plain string, so the overwrite wins and the prompt stays at the distro default
+// while the rest of the shell config still applies. It has no business being
+// forwarded regardless - this terminal renders through xterm.js, not VTE, so
+// claiming a VTE version also makes bash emit VTE title sequences every prompt.
+//
+// The rest are the same class of leak rather than reports in their own right.
+// Each was checked against an actual shell to confirm it can break prompt setup,
+// but none of them is the cause of #112.
+const SESSION_SCOPED_ENV_VARS: &[&str] = &[
+    "PS0",
+    "PS1",
+    "PS2",
+    "PS3",
+    "PS4",
+    "PROMPT",
+    "PROMPT_COMMAND",
+    "RPROMPT",
+    "RPS1",
+    "STARSHIP_DURATION",
+    "STARSHIP_JOBS_COUNT",
+    "STARSHIP_PREEXEC_READY",
+    "STARSHIP_SESSION_KEY",
+    "STARSHIP_SHELL",
+    "STARSHIP_START_TIME",
+    // Prompt frameworks detect bash-preexec by name. If one of these arrives in
+    // the environment without bash-preexec actually being loaded, starship's init
+    // takes its bash-preexec branch and registers into precmd_functions instead of
+    // PROMPT_COMMAND - arrays nothing ever runs - so the prompt is never drawn
+    // while the rest of .bashrc still takes effect. Reproduced by presetting any
+    // one of these; not what happens in #112, but the same failure.
+    "__bp_imported",
+    "bash_preexec_imported",
+    "precmd_functions",
+    "preexec_functions",
+    // Same story for ble.sh detection.
+    "BLE_ATTACHED",
+    "BLE_VERSION",
+    "_ble_version",
+    "BASH_ENV",
+    "ENV",
+    "SHLVL",
+    "OLDPWD",
+    "_",
+    "VTE_VERSION",
+    "VSCODE_INJECTION",
+    "VSCODE_NONCE",
+    "VSCODE_SHELL_ENV_REPORTING",
+    "VSCODE_SHELL_INTEGRATION",
+    "VSCODE_SHELL_LOGIN",
+];
+
+// Exported bash functions travel as BASH_FUNC_<name>%% and bring the previous
+// session's prompt hooks along with them.
+const SESSION_SCOPED_ENV_PREFIXES: &[&str] = &["BASH_FUNC_"];
+
+fn is_session_scoped_env(key: &str) -> bool {
+    SESSION_SCOPED_ENV_VARS.contains(&key)
+        || SESSION_SCOPED_ENV_PREFIXES
+            .iter()
+            .any(|prefix| key.starts_with(prefix))
+}
+
+// Config the user opted into (STARSHIP_CONFIG, TERM, PATH, ...) is left alone;
+// only the per-session leftovers listed above are removed.
+fn drop_session_scoped_env(cmd: &mut CommandBuilder) {
+    let stale: Vec<String> = cmd
+        .iter_full_env_as_str()
+        .map(|(key, _)| key.to_string())
+        .filter(|key| is_session_scoped_env(key))
+        .collect();
+
+    for key in stale {
+        cmd.env_remove(key);
+    }
+}
+
 pub(crate) fn resolve_windows_shell() -> String {
     for candidate in ["pwsh.exe", "powershell.exe"] {
         if let Ok(path) = which::which(candidate) {
@@ -239,6 +325,10 @@ pub fn terminal_spawn(
             cmd.env(k, v);
         }
     }
+
+    // Runs last so it also covers the env map the frontend sends, which is built
+    // from this process' own environment.
+    drop_session_scoped_env(&mut cmd);
 
     let child = pair
         .slave
@@ -672,4 +762,55 @@ fi
         .map_err(|e| format!("Failed to write .zlogin: {e}"))?;
 
     Ok(zdotdir.to_string_lossy().to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn drops_leftover_prompt_state() {
+        assert!(is_session_scoped_env("PS1"));
+        assert!(is_session_scoped_env("PROMPT_COMMAND"));
+        assert!(is_session_scoped_env("STARSHIP_SESSION_KEY"));
+        assert!(is_session_scoped_env("STARSHIP_SHELL"));
+        assert!(is_session_scoped_env("VTE_VERSION"));
+        assert!(is_session_scoped_env("BASH_FUNC_starship_precmd%%"));
+        assert!(is_session_scoped_env("__bp_imported"));
+        assert!(is_session_scoped_env("precmd_functions"));
+        assert!(is_session_scoped_env("preexec_functions"));
+        assert!(is_session_scoped_env("BLE_VERSION"));
+    }
+
+    #[test]
+    fn keeps_user_configuration() {
+        assert!(!is_session_scoped_env("STARSHIP_CONFIG"));
+        assert!(!is_session_scoped_env("STARSHIP_CACHE"));
+        assert!(!is_session_scoped_env("PATH"));
+        assert!(!is_session_scoped_env("HOME"));
+        assert!(!is_session_scoped_env("SHELL"));
+        assert!(!is_session_scoped_env("TERM"));
+    }
+
+    #[test]
+    fn removes_only_stale_vars_from_the_command() {
+        let mut cmd = CommandBuilder::new("/bin/bash");
+        cmd.env("PS1", "leftover");
+        cmd.env("PROMPT_COMMAND", "starship_precmd");
+        cmd.env("STARSHIP_CONFIG", "/home/user/.config/starship.toml");
+        cmd.env("TERM", "xterm-256color");
+
+        drop_session_scoped_env(&mut cmd);
+
+        assert!(cmd.get_env("PS1").is_none());
+        assert!(cmd.get_env("PROMPT_COMMAND").is_none());
+        assert_eq!(
+            cmd.get_env("STARSHIP_CONFIG"),
+            Some(std::ffi::OsStr::new("/home/user/.config/starship.toml"))
+        );
+        assert_eq!(
+            cmd.get_env("TERM"),
+            Some(std::ffi::OsStr::new("xterm-256color"))
+        );
+    }
 }


### PR DESCRIPTION
Fixes #112

## What happens

The integrated terminal inherits the environment of whatever process started SideX. Launched from a terminal, that environment carries the launching shell's session state into every shell SideX spawns; launched from the desktop menu, it starts from the clean session environment. `CommandBuilder` seeds its environment from `std::env::vars_os()`, and the env map the frontend sends is built from the same process environment, so nothing filtered it on either path.

On the reporter's system the variable that matters is `VTE_VERSION`, exported by gnome-terminal. The spawned login shell reads `/etc/profile`, which sources `/etc/profile.d/*.sh` in alphabetical order:

1. `starship.sh` sets `PROMPT_COMMAND="starship_precmd"`.
2. `vte-2.91.sh` runs after it and, with `VTE_VERSION` present, appends to `PROMPT_COMMAND` when it is a bash array and overwrites it otherwise. Starship leaves it a plain string, so the overwrite wins.
3. `~/.profile` then sources `~/.bashrc`, which sets a static PS1 and the user's aliases.

The aliases land and the prompt does not, which is exactly what was reported. It is bash-only because that assignment is vte.sh's bash branch and neither fish nor pwsh reads `/etc/profile`, and it needs a system-wide starship, because starship initialised from `~/.bashrc` runs after profile.d and wins. Confirmed against the reporter's own `/etc/profile.d/vte-2.91.sh` and their `diff` of the two environments, not a reconstruction.

## The change

`drop_session_scoped_env` removes session-scoped variables from the `CommandBuilder` immediately before spawn, which is late enough to also cover the env map the frontend re-applies.

The list separates two things:

- **`VTE_VERSION` is the confirmed cause of #112.** It is also wrong to forward on its own terms: this terminal renders through xterm.js, not VTE, so advertising a VTE version additionally makes bash emit VTE title sequences at every prompt.
- **The rest is defensive hygiene for the same class of leak**, found while investigating and each checked against a real shell, but none of them is what happens in #112. `PS0`-`PS4`, `PROMPT_COMMAND`, `RPROMPT`, starship's runtime variables, `SHLVL`, `OLDPWD`, `_`, `BASH_ENV`, `ENV`, exported bash functions, and the VS Code shell-integration markers. The bash-preexec and ble.sh detection names are the notable ones: if `__bp_imported`, `bash_preexec_imported`, `precmd_functions` or `preexec_functions` is present without bash-preexec actually being loaded, starship's init takes its bash-preexec branch and registers into arrays nothing ever runs, so the prompt is never drawn while the rest of `.bashrc` still applies. Reproduced by presetting any one of them.

Configuration the user opted into is deliberately kept: `STARSHIP_CONFIG`, `STARSHIP_CACHE`, `PATH`, `HOME`, `SHELL`, `TERM`. Stripping those would break the prompt from the other direction.

A menu launch has none of these variables, so the filter is a no-op there and both launch paths now hand the shell the same clean slate.

## Verification

- Three unit tests covering the matched names, the kept configuration, and removal against a real `CommandBuilder`: `cargo test --lib commands::terminal` passes, 3 passed / 0 failed.
- `cargo fmt --check` reports no diff for this file.
- `cargo clippy --no-deps --all-targets -- -D warnings` produces no diagnostics for this file.

Note for reviewers: the clippy gate is currently failing repo-wide for unrelated reasons on clippy 0.1.98 (274 findings in `sidex`, one in `sidex-text`), which looks like toolchain drift given there is no `rust-toolchain.toml` pin. Worth a separate pass.
