### PR TITLE
#103: add Quiet Light theme

### DIFF
--- a/crates/sidex-theme/src/default_themes.rs
+++ b/crates/sidex-theme/src/default_themes.rs
@@ -18,6 +18,16 @@ pub fn dark_modern() -> Theme {
     }
 }
 
+/// "Quiet Light" — the VS Code Quiet Light theme.
+pub fn quiet_light() -> Theme {
+    Theme {
+        name: "Quiet Light".to_owned(),
+        kind: ThemeKind::Light,
+        token_colors: quiet_light_tokens(),
+        workbench_colors: WorkbenchColors::quiet_light(),
+    }
+}
+
 /// "Default Light Modern" — the VS Code default light theme.
 pub fn light_modern() -> Theme {
     Theme {
@@ -487,6 +497,233 @@ fn light_modern_tokens() -> Vec<TokenColorRule> {
 }
 
 #[allow(clippy::too_many_lines)]
+fn quiet_light_tokens() -> Vec<TokenColorRule> {
+    vec![
+        // Base / comments
+        tok("source", "#333333"),
+        tok_styled("comment", "#AAAAAA", FontStyle::ITALIC),
+        tok_styled("comment.line", "#AAAAAA", FontStyle::ITALIC),
+        tok_styled("comment.block", "#AAAAAA", FontStyle::ITALIC),
+        tok_styled(
+            "comment.block.documentation",
+            "#448C27",
+            FontStyle::ITALIC,
+        ),
+        tok("punctuation.definition.comment", "#AAAAAA"),
+
+        // Strings
+        tok("string", "#448C27"),
+        tok("string.quoted.single", "#448C27"),
+        tok("string.quoted.double", "#448C27"),
+        tok("string.template", "#448C27"),
+        tok("string.quoted.template", "#448C27"),
+        tok("string.interpolated", "#448C27"),
+        tok("string.regexp", "#4B69C6"),
+        tok("constant.character.escape", "#9C5D27"),
+
+        // Numbers & constants
+        tok_multi(
+            &[
+                "constant.numeric",
+                "constant.numeric.integer",
+                "constant.numeric.float",
+                "constant.numeric.hex",
+                "constant.numeric.octal",
+                "constant.numeric.binary",
+            ],
+            "#9C5D27",
+        ),
+        tok("constant.language", "#9C5D27"),
+        tok("constant.language.boolean", "#9C5D27"),
+        tok("constant.language.null", "#9C5D27"),
+        tok("constant.language.undefined", "#9C5D27"),
+        tok("constant.character", "#9C5D27"),
+        tok("constant.other", "#9C5D27"),
+        tok("constant.regexp", "#4B69C6"),
+
+        // Variables
+        tok_multi(
+            &[
+                "variable",
+                "meta.definition.variable.name",
+                "support.variable",
+            ],
+            "#7A3E9D",
+        ),
+        tok("variable.other.readwrite", "#7A3E9D"),
+        tok("variable.other.constant", "#9C5D27"),
+        tok("variable.other.enummember", "#9C5D27"),
+        tok("variable.other.property", "#7A3E9D"),
+        tok("variable.other.object", "#7A3E9D"),
+        tok("variable.parameter", "#7A3E9D"),
+        tok("variable.language", "#4B69C6"),
+        tok("variable.language.this", "#4B69C6"),
+        tok("variable.language.self", "#4B69C6"),
+        tok("variable.language.super", "#4B69C6"),
+        tok("meta.object-literal.key", "#7A3E9D"),
+
+        // Keywords & storage
+        tok("keyword", "#4B69C6"),
+        tok_multi(
+            &[
+                "keyword.control",
+                "keyword.control.flow",
+                "keyword.control.loop",
+                "keyword.control.conditional",
+                "keyword.control.import",
+                "keyword.control.from",
+                "keyword.control.export",
+                "keyword.other.using",
+                "storage",
+                "storage.type",
+                "storage.modifier",
+            ],
+            "#4B69C6",
+        ),
+        tok("keyword.operator", "#777777"),
+        tok("keyword.operator.new", "#4B69C6"),
+        tok("keyword.operator.expression", "#4B69C6"),
+        tok("keyword.operator.logical", "#777777"),
+        tok("keyword.operator.assignment", "#777777"),
+        tok("keyword.operator.comparison", "#777777"),
+        tok("keyword.operator.type", "#4B69C6"),
+
+        // Functions
+        tok_styled(
+            "entity.name.function",
+            "#AA3731",
+            FontStyle::BOLD,
+        ),
+        tok_styled(
+            "entity.name.function.member",
+            "#AA3731",
+            FontStyle::BOLD,
+        ),
+        tok_styled("support.function", "#AA3731", FontStyle::BOLD),
+        tok_styled("meta.function-call", "#AA3731", FontStyle::BOLD),
+        tok_styled(
+            "support.function.builtin",
+            "#AA3731",
+            FontStyle::BOLD,
+        ),
+
+        // Types & classes
+        tok_styled(
+            "entity.name.type",
+            "#7A3E9D",
+            FontStyle::BOLD,
+        ),
+        tok_styled(
+            "entity.name.class",
+            "#7A3E9D",
+            FontStyle::BOLD,
+        ),
+        tok_styled("support.class", "#7A3E9D", FontStyle::BOLD),
+        tok("support.type", "#7A3E9D"),
+        tok("entity.name.type.parameter", "#7A3E9D"),
+        tok("entity.name.type.enum", "#7A3E9D"),
+        tok("entity.name.type.interface", "#7A3E9D"),
+        tok("entity.name.type.alias", "#7A3E9D"),
+        tok("entity.name.namespace", "#7A3E9D"),
+        tok("support.type.primitive", "#7A3E9D"),
+        tok_multi(
+            &["meta.type.cast.expr", "entity.other.inherited-class"],
+            "#7A3E9D",
+        ),
+
+        // HTML/XML/JSX
+        tok("entity.name.tag", "#4B69C6"),
+        tok("entity.name.tag.html", "#4B69C6"),
+        tok("entity.name.tag.css", "#91B3E0"),
+        tok("entity.other.attribute-name", "#8190A0"),
+
+        // CSS
+        tok("support.constant.property-value.css", "#448C27"),
+        tok("support.constant.font-name", "#448C27"),
+        tok("support.constant.color", "#448C27"),
+
+        // Decorators / attributes
+        tok_multi(
+            &[
+                "meta.decorator",
+                "entity.name.function.decorator",
+                "punctuation.decorator",
+            ],
+            "#AA3731",
+        ),
+        tok("meta.attribute", "#8190A0"),
+
+        // Preprocessor / macros
+        tok("meta.preprocessor", "#4B69C6"),
+        tok("meta.preprocessor.string", "#448C27"),
+        tok("meta.preprocessor.numeric", "#9C5D27"),
+        tok("entity.name.function.preprocessor", "#4B69C6"),
+        tok_multi(
+            &[
+                "keyword.control.directive",
+                "punctuation.definition.directive",
+            ],
+            "#4B69C6",
+        ),
+
+        // Operators & punctuation
+        tok("support.constant", "#9C5D27"),
+        tok("punctuation.definition.tag", "#91B3E0"),
+        tok("punctuation.separator", "#777777"),
+        tok("punctuation.terminator", "#777777"),
+        tok("punctuation.section", "#777777"),
+        tok("punctuation.accessor", "#777777"),
+        tok("meta.brace", "#777777"),
+
+        // JSON / YAML / TOML
+        tok("support.type.property-name.json", "#7A3E9D"),
+        tok("string.value.json", "#448C27"),
+        tok("entity.name.tag.yaml", "#4B69C6"),
+        tok("entity.name.tag.toml", "#4B69C6"),
+        tok("support.type.property-name.toml", "#7A3E9D"),
+
+        // Markdown / markup
+        tok_styled("emphasis", "#333333", FontStyle::ITALIC),
+        tok_styled("strong", "#333333", FontStyle::BOLD),
+        tok_styled("markup.heading", "#4B69C6", FontStyle::BOLD),
+        tok("markup.inserted", "#448C27"),
+        tok("markup.deleted", "#AA3731"),
+        tok("markup.changed", "#4B69C6"),
+        tok_styled("markup.italic", "#333333", FontStyle::ITALIC),
+        tok_styled("markup.bold", "#333333", FontStyle::BOLD),
+        tok_styled("markup.underline", "#333333", FontStyle::UNDERLINE),
+        tok_styled(
+            "markup.strikethrough",
+            "#333333",
+            FontStyle::STRIKETHROUGH,
+        ),
+        tok("markup.inline.raw", "#448C27"),
+        tok("markup.fenced_code.block", "#448C27"),
+        tok("markup.quote", "#448C27"),
+        tok("markup.list.numbered", "#4B69C6"),
+        tok("markup.list.unnumbered", "#4B69C6"),
+        tok("meta.link.inline.markdown", "#4B69C6"),
+        tok("string.other.link", "#4B69C6"),
+
+        // Rust
+        tok("entity.name.type.lifetime.rust", "#4B69C6"),
+        tok("keyword.operator.borrow.rust", "#4B69C6"),
+        tok("keyword.operator.sigil.rust", "#4B69C6"),
+        tok("entity.name.function.macro.rust", "#AA3731"),
+        tok("meta.attribute.rust", "#8190A0"),
+
+        // Invalid / deprecated
+        tok("invalid", "#cd3131"),
+        tok("invalid.illegal", "#660000"),
+        tok_styled(
+            "invalid.deprecated",
+            "#AA3731",
+            FontStyle::STRIKETHROUGH,
+        ),
+    ]
+}
+
+#[allow(clippy::too_many_lines)]
 fn hc_black_tokens() -> Vec<TokenColorRule> {
     vec![
         tok_styled("comment", "#7CA668", FontStyle::ITALIC),
@@ -787,5 +1024,13 @@ mod tests {
         let t = hc_light();
         assert_eq!(t.kind, ThemeKind::HighContrastLight);
         assert_eq!(t.workbench_colors.editor_background, c("#FFFFFF"));
+    }
+
+    #[test]
+    fn quiet_light_loads() {
+        let t = quiet_light();
+        assert_eq!(t.kind, ThemeKind::Light);
+        assert_eq!(t.workbench_colors.editor_background, c("#F5F5F5"));
+        assert!(!t.token_colors.is_empty());
     }
 }

--- a/crates/sidex-theme/src/lib.rs
+++ b/crates/sidex-theme/src/lib.rs
@@ -15,7 +15,7 @@ pub mod token_color;
 pub mod workbench_colors;
 
 pub use color::{blend_colors, color_to_hex, darken, hex_to_color, lighten, Color};
-pub use default_themes::{dark_modern, hc_black, hc_light, light_modern};
+pub use default_themes::{dark_modern, hc_black, hc_light, light_modern, quiet_light};
 pub use icon_theme::{FileIconTheme, IconInfo};
 pub use product_icons::{ProductIcon, ProductIconTheme};
 pub use theme::{Theme, ThemeKind};

--- a/crates/sidex-theme/src/theme_resolver.rs
+++ b/crates/sidex-theme/src/theme_resolver.rs
@@ -125,6 +125,7 @@ impl ThemeRegistry {
         let builtin = vec![
             crate::default_themes::dark_modern(),
             crate::default_themes::light_modern(),
+            crate::default_themes::quiet_light(),
             crate::default_themes::hc_black(),
             crate::default_themes::hc_light(),
         ];

--- a/crates/sidex-theme/src/workbench_colors.rs
+++ b/crates/sidex-theme/src/workbench_colors.rs
@@ -665,6 +665,72 @@ impl WorkbenchColors {
             ..Self::default()
         }
     }
+
+    /// VS Code "Quiet Light" workbench colors.
+    pub fn quiet_light() -> Self {
+        Self {
+            editor_background: c("#F5F5F5"),
+            editor_foreground: c("#333333"),
+            editor_whitespace_foreground: c("#AAAAAA"),
+            editor_line_highlight_background: c("#E4F6D4"),
+            editor_line_number_foreground: c("#6D705B"),
+            editor_line_number_active_foreground: c("#9769dc"),
+            editor_cursor_foreground: c("#54494B"),
+            editor_selection_background: c("#C9D0D9"),
+            minimap_selection_highlight: c("#C9D0D9"),
+
+            side_bar_background: c("#F2F2F2"),
+            side_bar_section_header_background: c("#ede8ef"),
+
+            panel_background: c("#F5F5F5"),
+
+            activity_bar_background: c("#EDEDF5"),
+            activity_bar_foreground: c("#705697"),
+            activity_bar_badge_background: c("#705697"),
+
+            title_bar_active_background: c("#c4b7d7"),
+
+            status_bar_background: c("#705697"),
+            status_bar_no_folder_background: c("#705697"),
+            status_bar_debugging_background: c("#705697"),
+
+            button_background: c("#705697"),
+
+            dropdown_background: c("#F5F5F5"),
+
+            selection_background: c("#C9D0D9"),
+            focus_border: c("#9769dc"),
+
+            list_active_selection_foreground: c("#6c6c6c"),
+            list_active_selection_background: c("#c4d9b1"),
+            list_inactive_selection_background: c("#d3dbcd"),
+            list_hover_background: c("#e0e0e0"),
+            list_highlight_foreground: c("#9769dc"),
+
+            input_option_active_border: c("#adafb7"),
+
+            editor_find_match_background: c("#BF9CAC"),
+            editor_find_match_highlight_background: c("#edc9d899"),
+
+            peek_view_editor_background: c("#F2F8FC"),
+            peek_view_title_background: c("#F2F8FC"),
+            peek_view_result_background: c("#F2F8FC"),
+            peek_view_border: c("#705697"),
+            peek_view_editor_match_highlight_background: c("#C2DFE3"),
+            peek_view_result_match_highlight_background: c("#93C6D6"),
+
+            welcome_page_tile_background: c("#f0f0f7"),
+
+            error_foreground: c("#f1897f"),
+
+            progress_bar_background: c("#705697"),
+
+            editor_indent_guide_background: c("#aaaaaa60"),
+            editor_indent_guide_active_background: c("#777777b0"),
+
+            ..Self::default()
+        }
+    }
 }
 
 fn c(hex: &str) -> Option<Color> {

--- a/src-tauri/src/commands/theme.rs
+++ b/src-tauri/src/commands/theme.rs
@@ -13,18 +13,21 @@ pub struct ThemeInfo {
 }
 
 #[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ThemeData {
     workbench_colors: HashMap<String, String>,
     token_colors: Vec<TokenColorRule>,
 }
 
 #[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct TokenColorRule {
     scope: Vec<String>,
     settings: TokenColorSettings,
 }
 
 #[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct TokenColorSettings {
     foreground: Option<String>,
     font_style: Option<String>,
@@ -63,12 +66,132 @@ fn font_style_str(fs: FontStyle) -> Option<String> {
     Some(parts.join(" "))
 }
 
+fn camel_to_vscode_key(key: &str) -> &'static str {
+    match key {
+        "editorBackground" => "editor.background",
+        "editorForeground" => "editor.foreground",
+        "editorLineHighlightBackground" => "editor.lineHighlightBackground",
+        "editorSelectionBackground" => "editor.selectionBackground",
+        "editorLineNumberForeground" => "editorLineNumber.foreground",
+        "editorLineNumberActiveForeground" => "editorLineNumber.activeForeground",
+        "editorCursorForeground" => "editorCursor.foreground",
+        "editorWhitespaceForeground" => "editorWhitespace.foreground",
+        "editorIndentGuideBackground" => "editorIndentGuide.background",
+        "editorIndentGuideActiveBackground" => "editorIndentGuide.activeBackground",
+        "editorRulerForeground" => "editorRuler.foreground",
+
+        "activityBarBackground" => "activityBar.background",
+        "activityBarForeground" => "activityBar.foreground",
+        "activityBarInactiveForeground" => "activityBar.inactiveForeground",
+        "activityBarBorder" => "activityBar.border",
+        "activityBarActiveBorder" => "activityBar.activeBorder",
+        "activityBarActiveBackground" => "activityBar.activeBackground",
+        "activityBarBadgeBackground" => "activityBarBadge.background",
+        "activityBarBadgeForeground" => "activityBarBadge.foreground",
+
+        "sideBarBackground" => "sideBar.background",
+        "sideBarForeground" => "sideBar.foreground",
+        "sideBarBorder" => "sideBar.border",
+        "sideBarTitleForeground" => "sideBarTitle.foreground",
+        "sideBarSectionHeaderBackground" => "sideBarSectionHeader.background",
+        "sideBarSectionHeaderForeground" => "sideBarSectionHeader.foreground",
+        "sideBarSectionHeaderBorder" => "sideBarSectionHeader.border",
+
+        "statusBarBackground" => "statusBar.background",
+        "statusBarForeground" => "statusBar.foreground",
+        "statusBarBorder" => "statusBar.border",
+        "statusBarDebuggingBackground" => "statusBar.debuggingBackground",
+        "statusBarDebuggingForeground" => "statusBar.debuggingForeground",
+        "statusBarNoFolderBackground" => "statusBar.noFolderBackground",
+        "statusBarNoFolderForeground" => "statusBar.noFolderForeground",
+
+        "editorGroupBorder" => "editorGroup.border",
+        "editorGroupHeaderTabsBackground" => "editorGroupHeader.tabsBackground",
+        "editorGroupHeaderTabsBorder" => "editorGroupHeader.tabsBorder",
+        "editorGroupHeaderNoTabsBackground" => "editorGroupHeader.noTabsBackground",
+        "editorPaneBackground" => "editorPane.background",
+        "tabActiveBackground" => "tab.activeBackground",
+        "tabActiveForeground" => "tab.activeForeground",
+        "tabInactiveBackground" => "tab.inactiveBackground",
+        "tabInactiveForeground" => "tab.inactiveForeground",
+        "tabBorder" => "tab.border",
+        "tabActiveBorder" => "tab.activeBorder",
+        "tabActiveBorderTop" => "tab.activeBorderTop",
+        "tabHoverBackground" => "tab.hoverBackground",
+
+        "panelBackground" => "panel.background",
+        "panelForeground" => "panel.foreground",
+        "panelBorder" => "panel.border",
+        "panelTitleActiveForeground" => "panelTitle.activeForeground",
+        "panelTitleActiveBorder" => "panelTitle.activeBorder",
+        "panelTitleInactiveForeground" => "panelTitle.inactiveForeground",
+
+        "listHoverBackground" => "list.hoverBackground",
+        "listHoverForeground" => "list.hoverForeground",
+        "listActiveSelectionBackground" => "list.activeSelectionBackground",
+        "listActiveSelectionForeground" => "list.activeSelectionForeground",
+        "listInactiveSelectionBackground" => "list.inactiveSelectionBackground",
+        "listInactiveSelectionForeground" => "list.inactiveSelectionForeground",
+        "listHighlightForeground" => "list.highlightForeground",
+
+        "inputBackground" => "input.background",
+        "inputForeground" => "input.foreground",
+        "inputBorder" => "input.border",
+        "inputPlaceholderForeground" => "input.placeholderForeground",
+        "inputOptionActiveBackground" => "inputOption.activeBackground",
+        "inputOptionActiveBorder" => "inputOption.activeBorder",
+        "inputOptionActiveForeground" => "inputOption.activeForeground",
+
+        "dropdownBackground" => "dropdown.background",
+        "dropdownForeground" => "dropdown.foreground",
+        "dropdownBorder" => "dropdown.border",
+        "buttonBackground" => "button.background",
+        "buttonForeground" => "button.foreground",
+        "buttonHoverBackground" => "button.hoverBackground",
+        "buttonBorder" => "button.border",
+
+        "badgeBackground" => "badge.background",
+        "badgeForeground" => "badge.foreground",
+        "progressBarBackground" => "progressBar.background",
+
+        "titleBarActiveBackground" => "titleBar.activeBackground",
+        "titleBarActiveForeground" => "titleBar.activeForeground",
+        "titleBarInactiveBackground" => "titleBar.inactiveBackground",
+        "titleBarInactiveForeground" => "titleBar.inactiveForeground",
+        "titleBarBorder" => "titleBar.border",
+
+        "editorFindMatchBackground" => "editor.findMatchBackground",
+        "editorFindMatchHighlightBackground" => "editor.findMatchHighlightBackground",
+        "peekViewBorder" => "peekView.border",
+        "peekViewEditorBackground" => "peekViewEditor.background",
+        "peekViewEditorMatchHighlightBackground" => "peekViewEditor.matchHighlightBackground",
+        "peekViewResultBackground" => "peekViewResult.background",
+        "peekViewResultMatchHighlightBackground" => "peekViewResult.matchHighlightBackground",
+        "peekViewTitleBackground" => "peekViewTitle.background",
+
+        "minimapSelectionHighlight" => "minimap.selectionHighlight",
+        "welcomePageTileBackground" => "welcomePage.tileBackground",
+        "selectionBackground" => "selection.background",
+
+        "notificationBackground" => "notifications.background",
+        "notificationForeground" => "notifications.foreground",
+        "notificationBorder" => "notifications.border",
+        "notificationLinkForeground" => "notificationLink.foreground",
+
+        _ => "",
+    }
+}
+
 fn workbench_colors_to_map(wb: &sidex_theme::WorkbenchColors) -> HashMap<String, String> {
     let json = serde_json::to_value(wb).unwrap_or_default();
     let mut map = HashMap::new();
     if let serde_json::Value::Object(obj) = json {
         for (key, val) in obj {
             if let Some(hex) = val.as_str() {
+                let vscode_key = camel_to_vscode_key(&key);
+                if !vscode_key.is_empty() {
+                    map.insert(vscode_key.to_owned(), hex.to_owned());
+                }
                 map.insert(key, hex.to_owned());
             }
         }
@@ -103,7 +226,7 @@ pub fn theme_list() -> Result<Vec<ThemeInfo>, String> {
         .into_iter()
         .map(|name| {
             let kind = match name {
-                "Default Light Modern" => ThemeKind::Light,
+                "Default Light Modern" | "Quiet Light" => ThemeKind::Light,
                 "Default High Contrast" => ThemeKind::HighContrast,
                 "Default High Contrast Light" => ThemeKind::HighContrastLight,
                 _ => ThemeKind::Dark,
@@ -125,12 +248,23 @@ pub fn theme_list() -> Result<Vec<ThemeInfo>, String> {
 pub fn theme_get(id: String) -> Result<ThemeData, String> {
     let mut registry = ThemeRegistry::new();
 
-    let label = id.replace('-', " ");
+    let id_trimmed = id
+        .trim_start_matches("vs-dark ")
+        .trim_start_matches("vs ")
+        .trim_start_matches("hc-black ")
+        .trim_start_matches("hc-light ")
+        .trim_start_matches("sidex-builtin-");
+    let label = id_trimmed.replace('-', " ").to_lowercase();
 
     let theme = registry
         .available_theme_names()
         .into_iter()
-        .find(|n| n.to_lowercase() == label)
+        .find(|n| {
+            *n == id
+                || n.eq_ignore_ascii_case(&id)
+                || n.to_lowercase() == label
+                || n.to_lowercase().replace(' ', "-") == id.to_lowercase()
+        })
         .map(std::borrow::ToOwned::to_owned);
 
     let Some(name) = theme else {
@@ -154,4 +288,56 @@ pub fn theme_get_default_dark() -> Result<ThemeData, String> {
 #[allow(clippy::unnecessary_wraps)]
 pub fn theme_get_default_light() -> Result<ThemeData, String> {
     Ok(theme_to_data(&Theme::default_light()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_theme_list_includes_quiet_light() {
+        let list = theme_list().expect("theme_list should succeed");
+        let ql = list.into_iter().find(|t| t.label == "Quiet Light");
+        assert!(ql.is_some(), "Quiet Light should be in theme_list");
+        let ql = ql.unwrap();
+        assert_eq!(ql.id, "quiet-light");
+        assert_eq!(ql.ui_theme, "vs");
+    }
+
+    #[test]
+    fn test_theme_get_by_various_ids() {
+        let data_by_name = theme_get("Quiet Light".to_string()).expect("should find by display name");
+        assert!(!data_by_name.workbench_colors.is_empty());
+        assert!(!data_by_name.token_colors.is_empty());
+        assert_eq!(
+            data_by_name.workbench_colors.get("editor.background"),
+            Some(&"#f5f5f5".to_string())
+        );
+
+        let data_by_slug = theme_get("quiet-light".to_string()).expect("should find by slug id");
+        assert_eq!(
+            data_by_slug.workbench_colors.get("editor.background"),
+            Some(&"#f5f5f5".to_string())
+        );
+
+        let data_by_builtin =
+            theme_get("sidex-builtin-quiet-light".to_string()).expect("should find by sidex-builtin id");
+        assert_eq!(
+            data_by_builtin.workbench_colors.get("editor.background"),
+            Some(&"#f5f5f5".to_string())
+        );
+    }
+
+    #[test]
+    fn test_workbench_colors_mapping_quiet_light() {
+        let theme = sidex_theme::default_themes::quiet_light();
+        let map = workbench_colors_to_map(&theme.workbench_colors);
+
+        assert_eq!(map.get("editor.background"), Some(&"#f5f5f5".to_string()));
+        assert_eq!(map.get("editor.foreground"), Some(&"#333333".to_string()));
+        assert_eq!(map.get("activityBar.background"), Some(&"#ededf5".to_string()));
+        assert_eq!(map.get("statusBar.background"), Some(&"#705697".to_string()));
+        assert_eq!(map.get("selection.background"), Some(&"#c9d0d9".to_string()));
+        assert_eq!(map.get("errorForeground"), Some(&"#f1897f".to_string()));
+    }
 }

--- a/src/vs/sidex-bridge.ts
+++ b/src/vs/sidex-bridge.ts
@@ -7,10 +7,14 @@
 declare global {
 	interface Window {
 		__TAURI__?: {
-			core: {
+			core?: {
 				invoke: (cmd: string, args?: Record<string, unknown>) => Promise<unknown>;
 			};
 		};
+		__TAURI_INTERNALS__?: {
+			invoke: (cmd: string, args?: Record<string, unknown>, options?: unknown) => Promise<unknown>;
+		};
+		__TAURI_INVOKE__?: (cmd: string, args?: Record<string, unknown>) => Promise<unknown>;
 	}
 }
 
@@ -18,6 +22,15 @@ let _invoke: ((cmd: string, args?: Record<string, unknown>) => Promise<unknown>)
 
 function getInvoke(): ((cmd: string, args?: Record<string, unknown>) => Promise<unknown>) | null {
 	if (_invoke) {
+		return _invoke;
+	}
+	const g = (typeof window !== 'undefined' ? window : (globalThis as any)) as Window;
+	if (g.__TAURI_INTERNALS__?.invoke) {
+		_invoke = (cmd, args) => g.__TAURI_INTERNALS__!.invoke(cmd, args);
+		return _invoke;
+	}
+	if (typeof g.__TAURI_INVOKE__ === 'function') {
+		_invoke = g.__TAURI_INVOKE__;
 		return _invoke;
 	}
 	if (window.__TAURI__?.core?.invoke) {

--- a/src/vs/workbench/services/themes/browser/workbenchThemeService.ts
+++ b/src/vs/workbench/services/themes/browser/workbenchThemeService.ts
@@ -71,8 +71,10 @@ import { mainWindow } from '../../../../base/browser/window.js';
 import { generateColorThemeCSS } from './colorThemeCss.js';
 import { INotificationService, Severity } from '../../../../platform/notification/common/notification.js';
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
+import { ISideXThemeService } from '../../../../platform/sidex/common/sidexThemeService.js';
 
 // implementation
+const SIDEX_QUIET_LIGHT_THEME_ID = 'Quiet Light';
 
 const defaultThemeExtensionId = 'vscode-theme-defaults';
 
@@ -100,6 +102,13 @@ function createBuiltInColorThemes(): ColorThemeData[] {
 			ThemeSettingDefaults.COLOR_THEME_LIGHT,
 			COLOR_THEME_LIGHT_INITIAL_COLORS,
 			nls.localize('lightModernDescription', 'Default light theme')
+		),
+		ColorThemeData.createLoadedTheme(
+			`${ThemeTypeSelector.VS} sidex-builtin-quiet-light`,
+			'Quiet Light',
+			'Quiet Light',
+			undefined,
+			nls.localize('quietLightDescription', 'Quiet Light theme')
 		),
 		ColorThemeData.createLoadedTheme(
 			`${ThemeTypeSelector.HC_BLACK} sidex-builtin-hc-black`,
@@ -165,6 +174,7 @@ export class WorkbenchThemeService extends Disposable implements IWorkbenchTheme
 
 	constructor(
 		@IExtensionService extensionService: IExtensionService,
+		@ISideXThemeService private readonly sideXThemeService: ISideXThemeService,
 		@IStorageService private readonly storageService: IStorageService,
 		@IConfigurationService private readonly configurationService: IConfigurationService,
 		@ITelemetryService private readonly telemetryService: ITelemetryService,
@@ -641,6 +651,18 @@ export class WorkbenchThemeService extends Disposable implements IWorkbenchTheme
 		});
 	}
 
+	private async loadThemeData(themeData: ColorThemeData): Promise<void> {
+		if (themeData.settingsId === SIDEX_QUIET_LIGHT_THEME_ID) {
+			const sideXTheme = await this.sideXThemeService.getTheme(SIDEX_QUIET_LIGHT_THEME_ID);
+			if (!sideXTheme) {
+				throw new Error(`Unable to load SideX theme: ${SIDEX_QUIET_LIGHT_THEME_ID}`);
+			}
+			themeData.setSideXThemeData(sideXTheme);
+		} else {
+			await themeData.ensureLoaded(this.extensionResourceLoaderService);
+		}
+	}
+
 	private async internalSetColorTheme(
 		themeIdOrTheme: string | undefined | IWorkbenchColorTheme,
 		settingsTarget: ThemeSettingTarget
@@ -665,7 +687,7 @@ export class WorkbenchThemeService extends Disposable implements IWorkbenchTheme
 			}
 		}
 		try {
-			await themeData.ensureLoaded(this.extensionResourceLoaderService);
+			await this.loadThemeData(themeData);
 			themeData.setCustomizations(this.settings);
 			return this.applyTheme(themeData, settingsTarget);
 		} catch (error) {
@@ -678,18 +700,19 @@ export class WorkbenchThemeService extends Disposable implements IWorkbenchTheme
 			) {
 				return null;
 			}
-			throw new Error(
-				nls.localize('error.cannotloadtheme', 'Unable to load {0}: {1}', themeData.location?.toString(), msg)
-			);
+			throw new Error(nls.localize('error.cannotloadtheme', 'Unable to load {0}: {1}', themeData.location?.toString(), msg));
 		}
 	}
 
 	private reloadCurrentColorTheme() {
 		return this.colorThemeSequencer.queue(async () => {
 			try {
-				const theme =
-					this.colorThemeRegistry.findThemeBySettingsId(this.currentColorTheme.settingsId) || this.currentColorTheme;
-				await theme.reload(this.extensionResourceLoaderService);
+				const theme = this.colorThemeRegistry.findThemeBySettingsId(this.currentColorTheme.settingsId) || this.currentColorTheme;
+				if (theme.settingsId === SIDEX_QUIET_LIGHT_THEME_ID) {
+					await this.loadThemeData(theme);
+				} else {
+					await theme.reload(this.extensionResourceLoaderService);
+				}
 				theme.setCustomizations(this.settings);
 				await this.applyTheme(theme, undefined, false);
 			} catch (_error) {
@@ -706,7 +729,7 @@ export class WorkbenchThemeService extends Disposable implements IWorkbenchTheme
 				if (settingId !== this.currentColorTheme.settingsId) {
 					await this.internalSetColorTheme(theme.id, undefined);
 				} else if (theme !== this.currentColorTheme) {
-					await theme.ensureLoaded(this.extensionResourceLoaderService);
+					await this.loadThemeData(theme);
 					theme.setCustomizations(this.settings);
 					await this.applyTheme(theme, undefined, true);
 				}

--- a/src/vs/workbench/services/themes/common/colorThemeData.ts
+++ b/src/vs/workbench/services/themes/common/colorThemeData.ts
@@ -451,6 +451,46 @@ export class ColorThemeData implements IWorkbenchColorTheme {
 		this.setCustomSemanticTokenColors(settings.semanticTokenColorCustomizations);
 	}
 
+	public setSideXThemeData(theme: {
+		workbenchColors?: Record<string, string>;
+		tokenColors?: Array<{
+			scope: string[];
+			settings: {
+				foreground?: string;
+				fontStyle?: string;
+				font_style?: string;
+			};
+		}>;
+		workbench_colors?: Record<string, string>;
+		token_colors?: Array<{
+			scope: string[];
+			settings: {
+				foreground?: string;
+				fontStyle?: string;
+				font_style?: string;
+			};
+		}>;
+	}) {
+		this.colorMap = {};
+
+		const workbenchColors = theme.workbenchColors ?? theme.workbench_colors ?? {};
+		for (const colorId in workbenchColors) {
+			this.colorMap[colorId] = Color.fromHex(workbenchColors[colorId]);
+		}
+
+		const tokenColors = theme.tokenColors ?? theme.token_colors ?? [];
+		this.themeTokenColors = tokenColors.map(rule => ({
+			scope: rule.scope,
+			settings: {
+				foreground: rule.settings.foreground,
+				fontStyle: rule.settings.fontStyle ?? rule.settings.font_style
+			}
+		}));
+
+		this.isLoaded = true;
+		this.clearCaches();
+	}
+
 	public setCustomColors(colors: IColorCustomizations) {
 		this.customColorMap = {};
 		this.overwriteCustomColors(colors);


### PR DESCRIPTION
# PR: Add Quiet Light Theme

## Summary

This PR adds the classic **Quiet Light** theme to SideX as a concrete contribution toward **#103**, which tracks the missing classic VS Code themes in SideX.

Quiet Light is now available as a built-in light theme and is integrated into the existing SideX theme system, including:

- Workbench/UI colors
- Syntax/token colors
- Theme registration and resolution
- Frontend theme selection
- Tauri IPC theme loading
- Tauri v2 runtime detection
- Theme data serialization
- Theme loading/reloading
- Automated tests

The implementation reuses the existing SideX architecture rather than introducing a separate theme-loading mechanism.

---

## Related Issue

**Part of #103**

Issue #103 tracks the fact that SideX currently provides significantly fewer built-in themes than VS Code, with several classic VS Code themes missing.

This PR implements **Quiet Light** as one of those missing themes.

> This PR intentionally uses `Part of #103` rather than `Closes #103`, since #103 is a broader issue covering multiple missing themes.

---

## What Changed

### 1. Added Quiet Light theme definition

Added a new built-in `Quiet Light` theme to the SideX theme system.

The theme includes:

- Light editor background and foreground
- Sidebar and activity bar styling
- Status bar styling
- Selection and hover colors
- Find/replace colors
- Peek view colors
- Input and validation colors
- Editor line highlighting
- Minimap colors
- Indentation guides
- Progress indicators
- Welcome page styling
- Other relevant workbench colors

The syntax highlighting was also added based on the VS Code Quiet Light theme, covering common language constructs such as:

- Comments
- Strings
- Numbers
- Variables
- Keywords
- Functions
- Classes/types
- Constants
- Operators
- HTML
- CSS
- JSON
- YAML
- TOML
- Markdown/markup
- Rust
- Decorators
- Preprocessor directives
- Invalid/deprecated syntax

---

### 2. Registered Quiet Light as a built-in theme

Quiet Light was added to the built-in theme registry and resolver so that it can be discovered and loaded in the same way as the existing built-in themes.

It is registered as a `Light` theme.

The frontend theme picker was also updated so that users can select **Quiet Light** directly from the available themes.

---

## Problems Encountered & Solutions

### Problem 1 — Quiet Light existed in the frontend picker but could not load

The first major issue was that simply adding Quiet Light to the theme picker was not enough.

The frontend attempted to request the theme from the SideX backend, but the runtime reported:

```text
[SideX] invoke(theme_get) – Tauri not available
Unable to load SideX theme: Quiet Light
```

Initially, the SideX bridge was checking for:

```ts
window.__TAURI__?.core?.invoke
```

However, SideX uses **Tauri v2**, and the runtime available in the application was exposing the invocation API through:

```ts
window.__TAURI_INTERNALS__.invoke
```

#### Solution

The Tauri bridge was updated to detect the available Tauri v2 invocation mechanism first, while retaining compatibility with the existing invocation paths.

The lookup now checks the available runtime mechanisms in order rather than assuming `window.__TAURI__` is always present.

This resolved the runtime error and allowed the frontend to successfully communicate with the Rust backend.

---

### Problem 2 — Theme data serialization between Rust and TypeScript

After getting the Tauri invocation working, another issue was ensuring that the theme data returned from Rust could be consumed correctly by the TypeScript theme system.

SideX's Rust `ThemeData` contains:

- Workbench colors
- Token colors
- Token color settings

The frontend expects these values in a structure compatible with the existing Monaco/VS Code theme infrastructure.

#### Solution

The Tauri theme command was updated to explicitly serialize the theme data using camelCase-compatible structures.

`ThemeData`, token color rules, and token settings now use the appropriate serialization configuration so that Rust data can be consumed cleanly from TypeScript.

The frontend loader was also made tolerant of both camelCase and snake_case representations where appropriate.

This makes the bridge more robust to the actual serialized structure coming from the Tauri command.

---

### Problem 3 — SideX workbench color names differ from VS Code color IDs

SideX's `WorkbenchColors` structure uses field names such as:

```text
editorBackground
editorLineHighlightBackground
selectionBackground
```

while VS Code/Monaco workbench colors use identifiers such as:

```text
editor.background
editor.lineHighlightBackground
selection.background
```

Simply serializing the Rust struct therefore wasn't sufficient for all consumers.

#### Solution

A mapping layer was added in the theme command.

Known SideX workbench color fields are translated into their corresponding VS Code-style color IDs.

For example:

```text
editorBackground
        ↓
editor.background

editorLineHighlightBackground
        ↓
editor.lineHighlightBackground

selectionBackground
        ↓
selection.background
```

The original serialized camelCase keys are also retained, which avoids unnecessarily breaking existing consumers of the SideX theme data.

---

### Problem 4 — Existing `ColorThemeData` loading expected extension themes

The existing frontend theme loader was primarily designed around themes loaded through the extension resource loader.

Quiet Light is different because it is a **native SideX built-in theme** whose data comes from the Tauri backend.

Using the normal extension-based loading path would therefore not work correctly.

#### Solution

A SideX-specific loading path was added to `ColorThemeData`.

When Quiet Light is selected:

1. The frontend requests the theme from the SideX theme service.
2. The Tauri command returns the workbench and token colors.
3. `ColorThemeData` converts the workbench colors into Monaco `Color` values.
4. Token color rules are populated.
5. Theme caches are cleared.
6. The theme is marked as loaded.

This allows Quiet Light to participate in the existing Monaco theme system without creating a completely separate theme implementation.

---

### Problem 5 — Theme reload/restore paths also needed to support Quiet Light

It wasn't enough to make Quiet Light work only when initially selected.

Theme loading can also happen through:

- Theme switching
- Reloading the current theme
- Restoring a previously selected theme

If only the initial selection path handled the SideX theme, one of these operations could fall back to the normal extension-based loader.

#### Solution

The SideX-specific theme loading helper is reused across the relevant theme lifecycle paths.

Quiet Light is therefore correctly handled when:

- Selected
- Reloaded
- Restored

while existing extension themes continue using the normal loading mechanism.

---

### Problem 6 — Theme IDs could differ between frontend and backend

Different parts of the application can refer to a theme using slightly different identifiers, for example:

```text
Quiet Light
quiet-light
sidex-builtin-quiet-light
vs sidex-builtin-quiet-light
```

A strict string comparison would make the theme unnecessarily fragile.

#### Solution

The backend theme lookup was made more tolerant.

Theme IDs are normalized before lookup, allowing Quiet Light to be resolved from the relevant identifier forms while still preserving the existing theme registry.

---

## Testing

The implementation was tested at both the Rust/theme-system level and the Tauri command level.

### Theme crate tests

```bash
cargo test -p sidex-theme
```

Result:

```text
57 passed
0 failed
```

### Tauri theme command tests

```bash
cargo test --manifest-path src-tauri/Cargo.toml commands::theme
```

Result:

```text
3 passed
0 failed
```

### Diff validation

```bash
git diff --check
```

Result:

```text
passed
```

No whitespace/errors were reported.

### Manual runtime verification

Quiet Light was also tested in the running SideX application.

Verified:

- Quiet Light appears in the theme selector.
- Quiet Light can be selected successfully.
- The theme loads through the SideX/Tauri theme pipeline.
- Editor/workbench colors are applied.
- Syntax highlighting is applied.
- Theme switching works.
- The Tauri runtime invocation issue is resolved.

---

## Implementation Notes

The implementation intentionally reuses the existing SideX theme architecture.

Rather than adding a completely separate frontend-only theme, Quiet Light is represented as a native SideX theme and passed through the existing:

```text
Rust Theme Registry
        ↓
Tauri theme_get command
        ↓
SideX Theme Service
        ↓
ColorThemeData
        ↓
Monaco Editor
```

This should make adding additional missing built-in VS Code themes easier in the future.

---

## Files Changed

Main areas modified:

- `crates/sidex-theme/src/default_themes.rs`
  - Added Quiet Light theme definition and token colors.

- `crates/sidex-theme/src/lib.rs`
  - Exported the new theme.

- `crates/sidex-theme/src/theme_resolver.rs`
  - Registered Quiet Light with the built-in theme resolver.

- `crates/sidex-theme/src/workbench_colors.rs`
  - Added Quiet Light workbench colors.

- `src-tauri/src/commands/theme.rs`
  - Added Quiet Light theme lookup/serialization and workbench color mapping.

- `src/vs/sidex-bridge.ts`
  - Updated Tauri runtime invocation detection.

- `src/vs/workbench/services/themes/browser/workbenchThemeService.ts`
  - Registered and integrated Quiet Light with the frontend theme lifecycle.

- `src/vs/workbench/services/themes/common/colorThemeData.ts`
  - Added support for loading native SideX theme data into the Monaco theme system.

---

## Result

SideX can now load and use **Quiet Light** as a built-in theme through its normal theme selection flow.

More importantly, the changes establish the integration required for additional built-in themes to be added without having to duplicate the entire theme-loading pipeline.